### PR TITLE
Mac OS X doesn't have setresuid() and setresgid().

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -53,6 +53,10 @@ AC_CHECK_HEADERS([ldns/ldns.h])
 
 # Checks for library functions.
 AC_CHECK_FUNCS([snprintf])
+AC_CHECK_FUNCS([setreuid])
+AC_CHECK_FUNCS([setresuid])
+AC_CHECK_FUNCS([setregid])
+AC_CHECK_FUNCS([setresgid])
 AC_CHECK_FUNC([ns_initparse],
     [AC_DEFINE([HAVE_NS_INITPARSE], [1], [Define to 1 if you have the `ns_initparse' function.])],
     AC_CHECK_FUNC(__ns_initparse,

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -72,6 +72,18 @@
 /* Define to 1 if you have the <resolv.h> header file. */
 #undef HAVE_RESOLV_H
 
+/* Define to 1 if you have the `setregid' function. */
+#undef HAVE_SETREGID
+
+/* Define to 1 if you have the `setresgid' function. */
+#undef HAVE_SETRESGID
+
+/* Define to 1 if you have the `setresuid' function. */
+#undef HAVE_SETRESUID
+
+/* Define to 1 if you have the `setreuid' function. */
+#undef HAVE_SETREUID
+
 /* Define to 1 if you have the `snprintf' function. */
 #undef HAVE_SNPRINTF
 
@@ -111,8 +123,7 @@
 /* Define to 1 if you have the `__assertion_failed' function. */
 #undef HAVE___ASSERTION_FAILED
 
-/* Define to the sub-directory in which libtool stores uninstalled libraries.
-   */
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
 #undef LT_OBJDIR
 
 /* Name of package */

--- a/src/dnscap.c
+++ b/src/dnscap.c
@@ -485,15 +485,29 @@ drop_privileges(void)
 		}
 	}
 
+#if HAVE_SETRESGID
 	if (setresgid(dropGID, dropGID, dropGID) < 0) {
 		fprintf(stderr, "Unable to drop GID to %s, exiting.\n", DROPTOUSER);
 		exit(1);
 	}
+#elif HAVE_SETREGID
+	if (setregid(dropGID, dropGID) < 0) {
+		fprintf(stderr, "Unable to drop GID to %s, exiting.\n", DROPTOUSER);
+		exit(1);
+	}
+#endif
 
+#if HAVE_SETRESUID
 	if (setresuid(dropUID, dropUID, dropUID) < 0) {
 		fprintf(stderr, "Unable to drop UID to %s, exiting.\n", DROPTOUSER);
 		exit(1);
 	}
+#elif HAVE_SETREUID
+	if (setreuid(dropUID, dropUID) < 0) {
+		fprintf(stderr, "Unable to drop UID to %s, exiting.\n", DROPTOUSER);
+		exit(1);
+	}
+#endif
 
 	// Testing if privileges are dropped
 	if (oldGID != getgid() && (setgid(oldGID) == 1 && setegid(oldGID) != 1)) {


### PR DESCRIPTION
This patch adds configure checks for setreuid() and setregid() and will use those
instead if the other versions are not available.