### PR TITLE
Work around configure problem detecting libresolv on Mac OS X

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -115,5 +115,6 @@ AC_CONFIG_FILES([
     plugins/pcapdump/Makefile
     plugins/rssm/Makefile
     plugins/txtout/Makefile
+    plugins/rzkeychange/Makefile
 ])
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -52,6 +52,7 @@ esac
 # Checks for header files.
 AC_HEADER_RESOLV
 AC_CHECK_HEADERS([arpa/inet.h fcntl.h netdb.h netinet/in.h stdlib.h string.h])
+AC_CHECK_HEADERS([arpa/nameser_compat.h])
 AC_CHECK_HEADERS([sys/ioctl.h sys/param.h sys/socket.h sys/time.h unistd.h])
 AC_CHECK_HEADERS([ldns/ldns.h])
 

--- a/configure.ac
+++ b/configure.ac
@@ -53,6 +53,10 @@ AC_CHECK_HEADERS([ldns/ldns.h])
 
 # Checks for library functions.
 AC_CHECK_FUNCS([snprintf])
+AC_CHECK_FUNCS([setreuid])
+AC_CHECK_FUNCS([setresuid])
+AC_CHECK_FUNCS([setregid])
+AC_CHECK_FUNCS([setresgid])
 AC_CHECK_FUNC([ns_initparse],
     [AC_DEFINE([HAVE_NS_INITPARSE], [1], [Define to 1 if you have the `ns_initparse' function.])],
     AC_CHECK_FUNC(__ns_initparse,

--- a/configure.ac
+++ b/configure.ac
@@ -17,7 +17,11 @@ LT_INIT([disable-static])
 
 # Checks for libraries.
 AC_CHECK_LIB([bind], [ns_initparse], [], [AC_CHECK_LIB([bind], [__ns_initparse])])
-AC_CHECK_LIB([resolv], [res_mkquery], [], [AC_CHECK_LIB([resolv], [__res_mkquery])])
+AC_CHECK_LIB([resolv], [res_mkquery], [], [
+	AC_CHECK_LIB([resolv], [__res_mkquery], [], [
+		AC_CHECK_LIB([resolv], [res_9_mkquery])
+	])
+])
 AC_CHECK_LIB([pcap], [pcap_open_live], [],
     [
     echo "dnscap requires libpcap.  Install package libpcap-dev on most Linux"

--- a/plugins/Makefile.am
+++ b/plugins/Makefile.am
@@ -1,5 +1,5 @@
 MAINTAINERCLEANFILES = $(srcdir)/Makefile.in
 
-SUBDIRS = pcapdump rssm txtout
+SUBDIRS = pcapdump rssm txtout rzkeychange
 
 EXTRA_DIST = template

--- a/plugins/pcapdump/pcapdump.c
+++ b/plugins/pcapdump/pcapdump.c
@@ -1,3 +1,4 @@
+#include "config.h"
 #define _GNU_SOURCE
 #include <stdio.h>
 #include <stdlib.h>
@@ -12,7 +13,7 @@
 #include <arpa/inet.h>
 #include <arpa/nameser.h>
 
-#ifdef __APPLE__
+#if HAVE_ARPA_NAMESER_COMPAT_H
 #include <arpa/nameser_compat.h>
 #endif
 

--- a/plugins/pcapdump/pcapdump.c
+++ b/plugins/pcapdump/pcapdump.c
@@ -12,6 +12,10 @@
 #include <arpa/inet.h>
 #include <arpa/nameser.h>
 
+#ifdef __APPLE__
+#include <arpa/nameser_compat.h>
+#endif
+
 #include "dnscap_common.h"
 
 #define SNAPLEN         65536

--- a/plugins/rssm/rssm.c
+++ b/plugins/rssm/rssm.c
@@ -1,3 +1,4 @@
+#include "config.h"
 #define _GNU_SOURCE
 #include <stdio.h>
 #include <stdlib.h>
@@ -11,7 +12,7 @@
 #include <arpa/inet.h>
 
 #include <arpa/nameser.h>
-#ifdef __APPLE__
+#if HAVE_ARPA_NAMESER_COMPAT_H
 #include <arpa/nameser_compat.h>
 #endif
 

--- a/plugins/rzkeychange/Makefile.am
+++ b/plugins/rzkeychange/Makefile.am
@@ -1,0 +1,14 @@
+MAINTAINERCLEANFILES = $(srcdir)/Makefile.in
+
+AM_CFLAGS = -I$(srcdir) \
+    -I$(top_srcdir)/src \
+    -I$(top_srcdir)/isc \
+    $(SECCOMPFLAGS)
+
+if LDNS
+pkglib_LTLIBRARIES = rzkeychange.la
+rzkeychange_la_SOURCES = rzkeychange.c hashtbl.c
+dist_rzkeychange_la_SOURCES = hashtbl.h
+rzkeychange_la_LDFLAGS = -module -version-info $(LIBRARY_VERSION)
+rzkeychange_la_LIBADD = -lldns
+endif

--- a/plugins/rzkeychange/hashtbl.c
+++ b/plugins/rzkeychange/hashtbl.c
@@ -1,0 +1,202 @@
+/*
+ * SuperFastHash implementation is from
+ *
+ * http://www.azillionmonkeys.com/qed/hash.html
+ */
+
+#include <unistd.h>
+#include <stdlib.h>
+#include <assert.h>
+#ifdef __linux__
+#include <stdint.h>
+#endif
+#include "hashtbl.h"
+
+hashtbl
+*hash_create(int N, hashfunc *hasher, hashkeycmp *cmp, hashfree *datafree)
+{
+	hashtbl *new = calloc(1, sizeof(*new));
+	assert(new);
+	new->modulus = N;
+	new->hasher = hasher;
+	new->keycmp = cmp;
+	new->datafree = datafree;
+	new->items = calloc(N, sizeof(hashitem*));
+	return new;
+}
+
+int
+hash_add(const void *key, void *data, hashtbl *tbl)
+{
+	hashitem *new = calloc(1, sizeof(*new));
+	hashitem **I;
+	int slot;
+	new->key = key;
+	new->data = data;
+	slot = tbl->hasher(key) % tbl->modulus;
+	for (I = &tbl->items[slot]; *I; I = &(*I)->next);
+	*I = new;
+	return 0;
+}
+
+void *
+hash_find(const void *key, hashtbl *tbl)
+{
+	int slot = tbl->hasher(key) % tbl->modulus;
+	hashitem *i;
+	for (i = tbl->items[slot]; i; i = i->next) {
+		if (0 == tbl->keycmp(key, i->key))
+		    return i->data;
+	}
+	return NULL;
+}
+
+int
+hash_count(hashtbl *tbl)
+{
+	int slot;
+	int count = 0;
+	for(slot = 0; slot < tbl->modulus; slot++) {
+		hashitem *i;
+		for (i = tbl->items[slot]; i; i=i->next)
+			count++;
+	}
+	return count;
+}
+
+void
+hash_remove(const void *key, hashtbl * tbl)
+{
+	hashitem **I, *i;
+	int slot;
+	slot = tbl->hasher(key) % tbl->modulus;
+	for (I = &tbl->items[slot]; *I; I = &(*I)->next) {
+		if (0 == tbl->keycmp(key, (*I)->key)) {
+			i = *I;
+			*I = (*I)->next;
+			if (i->data)
+				tbl->datafree(i->data);
+			free(i);
+			break;
+		}
+	}
+}
+
+void
+hash_free(hashtbl *tbl)
+{
+	int slot;
+	for(slot = 0; slot < tbl->modulus; slot++) {
+		hashitem *i;
+		hashitem *next;
+		for (i = tbl->items[slot]; i; i=next) {
+			next = i->next;
+			if (tbl->datafree)
+				tbl->datafree(i->data);
+			free(i);
+		}
+		tbl->items[slot] = NULL;
+	}
+}
+
+void
+hash_destroy(hashtbl *tbl)
+{
+	hash_free(tbl);
+	free(tbl->items);
+	free(tbl);
+}
+
+static void
+hash_iter_next_slot(hashtbl *tbl)
+{
+	while (tbl->iter.next == NULL) {
+		tbl->iter.slot++;
+		if (tbl->iter.slot == tbl->modulus)
+			break;
+		tbl->iter.next = tbl->items[tbl->iter.slot];
+	}
+}
+
+void
+hash_iter_init(hashtbl *tbl)
+{
+	tbl->iter.slot = 0;
+	tbl->iter.next = tbl->items[tbl->iter.slot];
+	if (NULL == tbl->iter.next)
+		hash_iter_next_slot(tbl);
+}
+
+void *
+hash_iterate(hashtbl *tbl)
+{
+	hashitem *this = tbl->iter.next;
+	if (this) {
+		tbl->iter.next = this->next;
+		if (NULL == tbl->iter.next)
+			hash_iter_next_slot(tbl);
+	}
+	return this ? this->data : NULL;
+}
+
+/*
+ * http://www.azillionmonkeys.com/qed/hash.html
+ */
+
+#undef get16bits
+#if (defined(__GNUC__) && defined(__i386__)) || defined(__WATCOMC__) \
+  || defined(_MSC_VER) || defined (__BORLANDC__) || defined (__TURBOC__)
+#define get16bits(d) (*((const uint16_t *) (d)))
+#endif
+
+#if !defined (get16bits)
+#define get16bits(d) ((((uint32_t)(((const uint8_t *)(d))[1])) << 8)\
+		       +(uint32_t)(((const uint8_t *)(d))[0]) )
+#endif
+
+unsigned int
+SuperFastHash (const char * data, int len)
+{
+    unsigned int hash = len, tmp;
+    int rem;
+
+    if (len <= 0 || data == NULL) return 0;
+
+    rem = len & 3;
+    len >>= 2;
+
+    /* Main loop */
+    for (;len > 0; len--) {
+	hash  += get16bits (data);
+	tmp    = (get16bits (data+2) << 11) ^ hash;
+	hash   = (hash << 16) ^ tmp;
+	data  += 2*sizeof (uint16_t);
+	hash  += hash >> 11;
+    }
+
+    /* Handle end cases */
+    switch (rem) {
+	case 3: hash += get16bits (data);
+		hash ^= hash << 16;
+		hash ^= data[sizeof (uint16_t)] << 18;
+		hash += hash >> 11;
+		break;
+	case 2: hash += get16bits (data);
+		hash ^= hash << 11;
+		hash += hash >> 17;
+		break;
+	case 1: hash += *data;
+		hash ^= hash << 10;
+		hash += hash >> 1;
+    }
+
+    /* Force "avalanching" of final 127 bits */
+    hash ^= hash << 3;
+    hash += hash >> 5;
+    hash ^= hash << 4;
+    hash += hash >> 17;
+    hash ^= hash << 25;
+    hash += hash >> 6;
+
+    return hash;
+}

--- a/plugins/rzkeychange/hashtbl.h
+++ b/plugins/rzkeychange/hashtbl.h
@@ -1,0 +1,33 @@
+typedef struct _hashitem {
+	const void *key;
+	void *data;
+	struct _hashitem *next;
+} hashitem;
+
+typedef unsigned int hashfunc(const void *key);
+typedef int hashkeycmp(const void *a, const void *b);
+typedef void hashfree(void *);
+
+typedef struct {
+	unsigned int modulus;
+	hashitem **items;
+	hashfunc *hasher;
+	hashkeycmp *keycmp;
+	hashfree *datafree;
+	struct {
+		hashitem *next;
+		unsigned int slot;
+	} iter;
+} hashtbl;
+
+hashtbl *hash_create(int N, hashfunc *, hashkeycmp *, hashfree *);
+int hash_add(const void *key, void *data, hashtbl *);
+void hash_remove(const void *key, hashtbl * tbl);
+void *hash_find(const void *key, hashtbl *);
+void hash_iter_init(hashtbl *);
+void *hash_iterate(hashtbl *);
+int hash_count(hashtbl *);
+void hash_free(hashtbl *);
+void hash_destroy(hashtbl *);
+
+extern unsigned int SuperFastHash (const char * data, int len);

--- a/plugins/rzkeychange/rzkeychange.c
+++ b/plugins/rzkeychange/rzkeychange.c
@@ -1,0 +1,223 @@
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <memory.h>
+#include <time.h>
+#include <stdarg.h>
+#include <errno.h>
+#include <assert.h>
+#include <sys/wait.h>
+#include <arpa/inet.h>
+
+#include <arpa/nameser.h>
+
+#include <netinet/in_systm.h>
+#include <netinet/in.h>
+#include <netinet/ip.h>
+#include <netinet/ip6.h>
+
+#include <ldns/ldns.h>
+
+#include "dnscap_common.h"
+
+#include "hashtbl.h"
+
+static logerr_t *logerr;
+static my_bpftimeval open_ts;
+static const char *report_zone = "rzkeychange.verisignlabs.com";
+
+output_t rzkeychange_output;
+
+#define MAX_TBL_ADDRS 2000000
+
+typedef struct {
+    hashtbl *tbl;
+    iaddr addrs[MAX_TBL_ADDRS];
+    unsigned int num_addrs;
+}      my_hashtbl;
+
+struct {
+    uint64_t dnskey;
+    uint64_t tc_bit;
+    uint64_t tcp;
+    uint64_t total;
+    my_hashtbl sources;
+}      counts;
+
+
+static unsigned int
+iaddr_hash(const iaddr * ia)
+{
+    if (AF_INET == ia->af)
+	return ia->u.a4.s_addr >> 8;
+    else if (AF_INET6 == ia->af) {
+	uint16_t *h = (uint16_t *) & ia->u;
+	return h[2] + h[3] + h[4];
+    } else
+	return 0;
+}
+
+static unsigned int
+iaddr_cmp(const iaddr * a, const iaddr * b)
+{
+    if (a->af == b->af) {
+	if (AF_INET == a->af)
+	    return memcmp(&a->u, &b->u, 4);
+	if (AF_INET6 == a->af)
+	    return memcmp(&a->u, &b->u, 16);
+	return 0;
+    }
+    if (a->af < b->af)
+	return -1;
+    return 1;
+}
+
+
+
+
+void
+rzkeychange_usage()
+{
+    fprintf(stderr,
+	"\nrzkeychange.so options:\n"
+	"\t-z <zone>  Report counters to DNS zone <zone>\n"
+
+    );
+}
+
+void
+rzkeychange_getopt(int *argc, char **argv[])
+{
+    int c;
+    while ((c = getopt(*argc, *argv, "z:")) != EOF) {
+	switch (c) {
+	case 'z':
+	    report_zone = strdup(optarg);
+	    break;
+	default:
+	    rzkeychange_usage();
+	    exit(1);
+	}
+    }
+}
+
+int
+rzkeychange_start(logerr_t * a_logerr)
+{
+    logerr = a_logerr;
+    return 0;
+}
+
+void
+rzkeychange_stop()
+{
+}
+
+int
+rzkeychange_open(my_bpftimeval ts)
+{
+    open_ts = ts;
+    if (counts.sources.tbl)
+	hash_destroy(counts.sources.tbl);
+    memset(&counts, 0, sizeof(counts));
+    counts.sources.tbl = hash_create(65536, (hashfunc *) iaddr_hash, (hashkeycmp *) iaddr_cmp, 0);
+    return 0;
+}
+
+void
+rzkeychange_submit_counts(void)
+{
+    char qname[256];
+    snprintf(qname, sizeof(qname), "%lu-%"PRIu64"-%"PRIu64"-%"PRIu64"-%"PRIu64".%s",
+	open_ts.tv_sec,
+	counts.total,
+	counts.dnskey,
+	counts.tcp,
+	counts.tc_bit,
+	report_zone);
+    fputs(qname, stderr);
+    fputc('\n', stderr);
+}
+
+/*
+ * Fork a separate process so that we don't block the main dnscap.  Use
+ * double-fork to avoid zombies for the main dnscap process.
+ */
+int
+rzkeychange_close(my_bpftimeval ts)
+{
+    pid_t pid;
+    pid = fork();
+    if (pid < 0) {
+	logerr("rzkeychange.so: fork: %s", strerror(errno));
+	return 1;
+    } else if (pid) {
+	/* parent */
+	waitpid(pid, NULL, 0);
+	return 0;
+    }
+    /* 1st gen child continues */
+    pid = fork();
+    if (pid < 0) {
+	logerr("rzkeychange.so: fork: %s", strerror(errno));
+	return 1;
+    } else if (pid) {
+	/* 1st gen child exits */
+	exit(0);
+    }
+    /* grandchild (2nd gen) continues */
+    rzkeychange_submit_counts();
+    exit(0);
+}
+
+static void
+hash_find_or_add(iaddr ia, my_hashtbl * t)
+{
+    uint16_t *c = hash_find(&ia, t->tbl);
+    if (c)
+	return;
+    if (t->num_addrs == MAX_TBL_ADDRS)
+	return;
+    t->addrs[t->num_addrs] = ia;
+    hash_add(&t->addrs[t->num_addrs], 0, t->tbl);
+    t->num_addrs++;
+}
+
+void
+rzkeychange_output(const char *descr, iaddr from, iaddr to, uint8_t proto, int isfrag,
+    unsigned sport, unsigned dport, my_bpftimeval ts,
+    const u_char * pkt_copy, unsigned olen,
+    const u_char * dnspkt, unsigned dnslen)
+{
+    ldns_pkt *pkt = 0;
+    ldns_rr_list *question_rr_list = 0;
+    ldns_rr *question_rr = 0;
+    if (!dnspkt)
+	return;
+    if (LDNS_STATUS_OK != ldns_wire2pkt(&pkt, dnspkt, dnslen))
+	return;
+    if (0 == ldns_pkt_qr(pkt))
+	goto done;
+    counts.total++;
+    hash_find_or_add(from, &counts.sources);
+    if (IPPROTO_UDP == proto) {
+	if (0 != ldns_pkt_tc(pkt))
+	    counts.tc_bit++;
+    } else if (IPPROTO_TCP == proto) {
+	counts.tcp++;
+    }
+    if (LDNS_PACKET_QUERY != ldns_pkt_get_opcode(pkt))
+	goto done;
+    question_rr_list = ldns_pkt_question(pkt);
+    if (0 == question_rr_list)
+	goto done;
+    question_rr = ldns_rr_list_rr(question_rr_list, 0);
+    if (0 == question_rr)
+	goto done;
+    if (LDNS_RR_CLASS_IN == ldns_rr_get_class(question_rr))
+	if (LDNS_RR_TYPE_DNSKEY == ldns_rr_get_type(question_rr))
+	    counts.dnskey++;
+done:
+    ldns_pkt_free(pkt);
+}

--- a/plugins/txtout/txtout.c
+++ b/plugins/txtout/txtout.c
@@ -127,8 +127,8 @@ txtout_output(const char *descr, iaddr from, iaddr to, uint8_t proto, int isfrag
 	 * IP Stuff
 	 */
 	fprintf(out, "%10lu.%06lu", ts.tv_sec, ts.tv_usec);
-	fprintf(out, " %s %hu", ia_str(from), sport);
-	fprintf(out, " %s %hu", ia_str(to), dport);
+	fprintf(out, " %s %u", ia_str(from), sport);
+	fprintf(out, " %s %u", ia_str(to), dport);
 	fprintf(out, " %hhu", proto);
 
 	if (dnspkt) {

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -3,6 +3,9 @@
 /* Define to 1 if you have the <arpa/inet.h> header file. */
 #undef HAVE_ARPA_INET_H
 
+/* Define to 1 if you have the <arpa/nameser_compat.h> header file. */
+#undef HAVE_ARPA_NAMESER_COMPAT_H
+
 /* Define to 1 if you have the <arpa/nameser.h> header file. */
 #undef HAVE_ARPA_NAMESER_H
 

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -72,6 +72,18 @@
 /* Define to 1 if you have the <resolv.h> header file. */
 #undef HAVE_RESOLV_H
 
+/* Define to 1 if you have the `setregid' function. */
+#undef HAVE_SETREGID
+
+/* Define to 1 if you have the `setresgid' function. */
+#undef HAVE_SETRESGID
+
+/* Define to 1 if you have the `setresuid' function. */
+#undef HAVE_SETRESUID
+
+/* Define to 1 if you have the `setreuid' function. */
+#undef HAVE_SETREUID
+
 /* Define to 1 if you have the `snprintf' function. */
 #undef HAVE_SNPRINTF
 
@@ -111,8 +123,7 @@
 /* Define to 1 if you have the `__assertion_failed' function. */
 #undef HAVE___ASSERTION_FAILED
 
-/* Define to the sub-directory in which libtool stores uninstalled libraries.
-   */
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
 #undef LT_OBJDIR
 
 /* Name of package */

--- a/src/dnscap.c
+++ b/src/dnscap.c
@@ -485,15 +485,29 @@ drop_privileges(void)
 		}
 	}
 
+#if HAVE_SETRESGID
 	if (setresgid(dropGID, dropGID, dropGID) < 0) {
 		fprintf(stderr, "Unable to drop GID to %s, exiting.\n", DROPTOUSER);
 		exit(1);
 	}
+#elif HAVE_SETREGID
+	if (setregid(dropGID, dropGID) < 0) {
+		fprintf(stderr, "Unable to drop GID to %s, exiting.\n", DROPTOUSER);
+		exit(1);
+	}
+#endif
 
+#if HAVE_SETRESUID
 	if (setresuid(dropUID, dropUID, dropUID) < 0) {
 		fprintf(stderr, "Unable to drop UID to %s, exiting.\n", DROPTOUSER);
 		exit(1);
 	}
+#elif HAVE_SETREUID
+	if (setreuid(dropUID, dropUID) < 0) {
+		fprintf(stderr, "Unable to drop UID to %s, exiting.\n", DROPTOUSER);
+		exit(1);
+	}
+#endif
 
 	// Testing if privileges are dropped
 	if (oldGID != getgid() && (setgid(oldGID) == 1 && setegid(oldGID) != 1)) {

--- a/src/dnscap.c
+++ b/src/dnscap.c
@@ -73,7 +73,6 @@ static const char version_fmt[] = "V1.0-OARC-r%d (%s)";
 #ifdef __APPLE__
 # include <net/ethernet.h>
 # include <net/bpf.h>
-# include <arpa/nameser_compat.h>
 #endif
 
 #ifdef __hpux
@@ -108,6 +107,9 @@ static const char version_fmt[] = "V1.0-OARC-r%d (%s)";
 #include <netinet/udp.h>
 #include <netinet/tcp.h>
 #include <arpa/nameser.h>
+#if HAVE_ARPA_NAMESER_COMPAT_H
+#include <arpa/nameser_compat.h>
+#endif
 #include <arpa/inet.h>
 
 #include <assert.h>


### PR DESCRIPTION
Without some #include files, the configure test won't find the
symbol res_mkquery() in libresolv on OS X.  It is called res_9_mkquery()
here.