### PR TITLE
A change to the interface of the family of output() functions.

### DIFF
--- a/plugins/pcapdump/pcapdump.c
+++ b/plugins/pcapdump/pcapdump.c
@@ -186,13 +186,13 @@ pcapdump_close(my_bpftimeval ts)
 }
 
 void
-pcapdump_output(const char *descr, iaddr from, iaddr to, uint8_t proto, int isfrag,
+pcapdump_output(const char *descr, iaddr from, iaddr to, uint8_t proto, int isfrag, int isdns,
     unsigned sport, unsigned dport, my_bpftimeval ts,
-    const u_char * pkt_copy, unsigned olen, const u_char * dnspkt, unsigned dnslen)
+    const u_char * pkt_copy, const unsigned olen, const u_char * payload, const unsigned payloadlen)
 {
     struct pcap_pkthdr h;
-    if (dnspkt) {
-        HEADER *dns = (HEADER *) dnspkt;
+    if (isdns) {
+        HEADER *dns = (HEADER *) payload;
         if (0 == dns->qr && 0 == (dir_wanted&DIR_INITIATE))
 	    return;
         if (1 == dns->qr && 0 == (dir_wanted&DIR_RESPONSE))

--- a/plugins/pcapdump/pcapdump.c
+++ b/plugins/pcapdump/pcapdump.c
@@ -186,12 +186,12 @@ pcapdump_close(my_bpftimeval ts)
 }
 
 void
-pcapdump_output(const char *descr, iaddr from, iaddr to, uint8_t proto, int isfrag, int isdns,
+pcapdump_output(const char *descr, iaddr from, iaddr to, uint8_t proto, unsigned flags,
     unsigned sport, unsigned dport, my_bpftimeval ts,
     const u_char * pkt_copy, const unsigned olen, const u_char * payload, const unsigned payloadlen)
 {
     struct pcap_pkthdr h;
-    if (isdns) {
+    if (flags & DNSCAP_OUTPUT_ISDNS) {
         HEADER *dns = (HEADER *) payload;
         if (0 == dns->qr && 0 == (dir_wanted&DIR_INITIATE))
 	    return;

--- a/plugins/rssm/rssm.c
+++ b/plugins/rssm/rssm.c
@@ -294,12 +294,12 @@ hash_find_or_add(iaddr ia, my_hashtbl *t)
 }
 
 void
-rssm_output(const char *descr, iaddr from, iaddr to, uint8_t proto, int isfrag, int isdns,
+rssm_output(const char *descr, iaddr from, iaddr to, uint8_t proto, unsigned flags,
     unsigned sport, unsigned dport, my_bpftimeval ts,
     const u_char *pkt_copy, const unsigned olen,
     const u_char *payload, const unsigned payloadlen)
 {
-	if (!isdns)
+	if (!(flags & DNSCAP_OUTPUT_ISDNS))
 		return;
 	unsigned dnslen = payloadlen >> MSG_SIZE_SHIFT;
 	if (dnslen >= MAX_SIZE_INDEX)

--- a/plugins/template/template.c
+++ b/plugins/template/template.c
@@ -94,7 +94,7 @@ template_close(my_bpftimeval ts)
 }
 
 void
-template_output(const char *descr, iaddr from, iaddr to, uint8_t proto, int isfrag, int isdns,
+template_output(const char *descr, iaddr from, iaddr to, uint8_t proto, unsigned flags,
     unsigned sport, unsigned dport, my_bpftimeval ts,
     const u_char *pkt_copy, const unsigned olen,
     const u_char *payload, const unsigned payloadlen)
@@ -104,6 +104,6 @@ template_output(const char *descr, iaddr from, iaddr to, uint8_t proto, int isfr
 	 * "output" because in the original code this is where
 	 * packets were outputted.
 	 *
-	 * if isdns != 0 then payload is the start of a DNS message.
+	 * if flags & PCAP_OUTPUT_ISDNS != 0 then payload is the start of a DNS message.
 	 */
 }

--- a/plugins/template/template.c
+++ b/plugins/template/template.c
@@ -94,17 +94,16 @@ template_close(my_bpftimeval ts)
 }
 
 void
-template_output(const char *descr, iaddr from, iaddr to, uint8_t proto, int isfrag,
+template_output(const char *descr, iaddr from, iaddr to, uint8_t proto, int isfrag, int isdns,
     unsigned sport, unsigned dport, my_bpftimeval ts,
-    const u_char *pkt_copy, unsigned olen,
-    const u_char *dnspkt, unsigned dnslen)
+    const u_char *pkt_copy, const unsigned olen,
+    const u_char *payload, const unsigned payloadlen)
 {
 	/*
 	 * Here you can "process" a packet.  The function is named
 	 * "output" because in the original code this is where
 	 * packets were outputted.
 	 *
-	 * Note that dnspkt may be NULL if the IP packet does not
-	 * appear to contain a valid DNS message.
+	 * if isdns != 0 then payload is the start of a DNS message.
 	 */
 }

--- a/plugins/txtout/txtout.c
+++ b/plugins/txtout/txtout.c
@@ -118,7 +118,7 @@ ia_str(iaddr ia) {
 }
 
 void
-txtout_output(const char *descr, iaddr from, iaddr to, uint8_t proto, int isfrag, int isdns,
+txtout_output(const char *descr, iaddr from, iaddr to, uint8_t proto, unsigned flags,
     unsigned sport, unsigned dport, my_bpftimeval ts,
     const u_char *pkt_copy, unsigned olen,
     const u_char *payload, unsigned payloadlen)
@@ -131,7 +131,7 @@ txtout_output(const char *descr, iaddr from, iaddr to, uint8_t proto, int isfrag
 	fprintf(out, " %s %u", ia_str(to), dport);
 	fprintf(out, " %hhu", proto);
 
-	if (isdns) {
+	if (flags & DNSCAP_OUTPUT_ISDNS) {
 		ns_msg msg;
 		int qdcount;
 		ns_rr rr;

--- a/plugins/txtout/txtout.c
+++ b/plugins/txtout/txtout.c
@@ -118,10 +118,10 @@ ia_str(iaddr ia) {
 }
 
 void
-txtout_output(const char *descr, iaddr from, iaddr to, uint8_t proto, int isfrag,
+txtout_output(const char *descr, iaddr from, iaddr to, uint8_t proto, int isfrag, int isdns,
     unsigned sport, unsigned dport, my_bpftimeval ts,
     const u_char *pkt_copy, unsigned olen,
-    const u_char *dnspkt, unsigned dnslen)
+    const u_char *payload, unsigned payloadlen)
 {
 	/*
 	 * IP Stuff
@@ -131,11 +131,11 @@ txtout_output(const char *descr, iaddr from, iaddr to, uint8_t proto, int isfrag
 	fprintf(out, " %s %u", ia_str(to), dport);
 	fprintf(out, " %hhu", proto);
 
-	if (dnspkt) {
+	if (isdns) {
 		ns_msg msg;
 		int qdcount;
 		ns_rr rr;
-		ns_initparse(dnspkt, dnslen, &msg);
+		ns_initparse(payload, payloadlen, &msg);
 		/*
 		 * DNS Header
 		 */

--- a/src/dnscap.c
+++ b/src/dnscap.c
@@ -1825,8 +1825,8 @@ network_pkt(const char *descr, my_bpftimeval ts, unsigned pf,
 	unsigned proto, sport, dport;
 	iaddr from, to, initiator, responder;
 	struct ip6_hdr *ipv6;
-	int response, isfrag;
-	int isdns;
+	int response;
+	unsigned flags = 0;
 	struct udphdr *udp = NULL;
 	struct tcphdr *tcp = NULL;
 	tcpstate_ptr tcpstate = NULL;
@@ -1840,8 +1840,6 @@ network_pkt(const char *descr, my_bpftimeval ts, unsigned pf,
 	/* Network. */
 	ip = NULL;
 	ipv6 = NULL;
-	isfrag = FALSE;
-	isdns = FALSE;
 	sport = dport = 0;
 	switch (pf) {
 	case PF_INET: {
@@ -1871,8 +1869,8 @@ network_pkt(const char *descr, my_bpftimeval ts, unsigned pf,
 		    (offset & IP_OFFMASK) != 0)
 		{
 			if (wantfrags) {
-				isfrag = TRUE;
-				output(descr, from, to, ip->ip_p, isfrag, isdns, sport, dport, ts, pkt_copy, olen, pkt, len);
+				flags |= DNSCAP_OUTPUT_ISFRAG;
+				output(descr, from, to, ip->ip_p, flags, sport, dport, ts, pkt_copy, olen, pkt, len);
 				return;
 			}
 			return;
@@ -1921,8 +1919,8 @@ network_pkt(const char *descr, my_bpftimeval ts, unsigned pf,
 			/* Cannot handle fragments. */
 			if (nexthdr == IPPROTO_FRAGMENT) {
 				if (wantfrags) {
-					isfrag = TRUE;
-					output(descr, from, to, IPPROTO_FRAGMENT, isfrag, isdns, sport, dport, ts, pkt_copy, olen, pkt, len);
+					flags |= DNSCAP_OUTPUT_ISFRAG;
+					output(descr, from, to, IPPROTO_FRAGMENT, flags, sport, dport, ts, pkt_copy, olen, pkt, len);
 					return;
 				}
 				return;
@@ -1956,7 +1954,7 @@ network_pkt(const char *descr, my_bpftimeval ts, unsigned pf,
 	switch (proto) {
 	case IPPROTO_ICMP:
 	case IPPROTO_ICMPV6:
-		output(descr, from, to, ip->ip_p, isfrag, isdns, sport, dport, ts, pkt_copy, olen, pkt, len);
+		output(descr, from, to, ip->ip_p, flags, sport, dport, ts, pkt_copy, olen, pkt, len);
 		return;
 	case IPPROTO_UDP: {
 		if (len < sizeof *udp)
@@ -1975,7 +1973,7 @@ network_pkt(const char *descr, my_bpftimeval ts, unsigned pf,
 		len -= sizeof *udp;
 		dnspkt = pkt;
 		dnslen = len;
-		isdns = TRUE;
+		flags |= DNSCAP_OUTPUT_ISDNS;
 		break;
 	}
 	case IPPROTO_TCP: {
@@ -2042,7 +2040,7 @@ network_pkt(const char *descr, my_bpftimeval ts, unsigned pf,
 		    /* Always output FIN and RST segments. */
 		    if (dumptrace >= 3)
 			fprintf(stderr, "FIN|RST\n");
-		    output(descr, from, to, proto, isfrag, isdns, sport, dport, ts,
+		    output(descr, from, to, proto, flags, sport, dport, ts,
 			pkt_copy, olen, pkt, len);
 		    /* End of stream; deallocate the tcpstate. */
 		    if (tcpstate) {
@@ -2056,7 +2054,7 @@ network_pkt(const char *descr, my_bpftimeval ts, unsigned pf,
 		    if (dumptrace >= 3)
 			fprintf(stderr, "SYN\n");
 		    /* Always output SYN segments. */
-		    output(descr, from, to, proto, isfrag, isdns, sport, dport, ts,
+		    output(descr, from, to, proto, flags, sport, dport, ts,
 			pkt_copy, olen, pkt, len);
 		    if (tcpstate) {
 #if 0
@@ -2097,7 +2095,7 @@ network_pkt(const char *descr, my_bpftimeval ts, unsigned pf,
 			dnspkt = pkt + 2;
 			if (dnslen > len - 2)
 			    dnslen = len - 2;
-			isdns = TRUE;
+			flags |= DNSCAP_OUTPUT_ISDNS;
 			tcpstate->maxdiff = (uint32_t)len;
 		    } else if (seqdiff == 0 && len == 2) {
 			/* This is the first segment of the stream, but only
@@ -2106,7 +2104,7 @@ network_pkt(const char *descr, my_bpftimeval ts, unsigned pf,
 			    fprintf(stderr, "len\n");
 			tcpstate->dnslen = (pkt[0] << 8) | (pkt[1] << 0);
 			tcpstate->maxdiff = (uint32_t)len;
-			output(descr, from, to, proto, isfrag, isdns, sport, dport, ts,
+			output(descr, from, to, proto, flags, sport, dport, ts,
 			    pkt_copy, olen, pkt, len);
 			return;
 		    } else if ((seqdiff == 0 && len == 1) || seqdiff == 1) {
@@ -2125,7 +2123,7 @@ network_pkt(const char *descr, my_bpftimeval ts, unsigned pf,
 			    dnslen = len;
 			if (dnslen > len)
 			    dnslen = len;
-			isdns = TRUE;
+			flags |= DNSCAP_OUTPUT_ISDNS;
 		    } else if (seqdiff > tcpstate->maxdiff + MAX_TCP_WINDOW) {
 			/* This segment is outside the window. */
 			if (dumptrace >= 3)
@@ -2142,7 +2140,7 @@ network_pkt(const char *descr, my_bpftimeval ts, unsigned pf,
 			    fprintf(stderr, "keep\n");
 			if (tcpstate->maxdiff < seqdiff + (uint32_t)len)
 			    tcpstate->maxdiff = seqdiff + (uint32_t)len;
-			output(descr, from, to, proto, isfrag, isdns, sport, dport, ts,
+			output(descr, from, to, proto, flags, sport, dport, ts,
 			    pkt_copy, olen, pkt, len);
 			return;
 		    }
@@ -2347,15 +2345,15 @@ network_pkt(const char *descr, my_bpftimeval ts, unsigned pf,
 		}
 	}
 	msgcount++;
-	output(descr, from, to, proto, isfrag, isdns, sport, dport, ts,
+	output(descr, from, to, proto, flags, sport, dport, ts,
 	    pkt_copy, olen, dnspkt, dnslen);
 }
 
 /*
- * when isdns = TRUE, payload points to a DNS packet
+ * when flags & DNSCAP_OUTPUT_ISDNS, payload points to a DNS packet
  */
 static void
-output(const char *descr, iaddr from, iaddr to, uint8_t proto, int isfrag, int isdns,
+output(const char *descr, iaddr from, iaddr to, uint8_t proto, unsigned flags,
     unsigned sport, unsigned dport, my_bpftimeval ts,
     const u_char *pkt_copy, const unsigned olen,
     const u_char *payload, const unsigned payloadlen)
@@ -2364,13 +2362,13 @@ output(const char *descr, iaddr from, iaddr to, uint8_t proto, int isfrag, int i
 	/* Output stage. */
 	if (preso) {
 		fputs(descr, stderr);
-		if (isfrag) {
+		if (flags & DNSCAP_OUTPUT_ISFRAG) {
 			fprintf(stderr, ";: [%s] ", ia_str(from));
 			fprintf(stderr, "-> [%s] (frag)\n", ia_str(to));
 		} else {
 			fprintf(stderr, "\t[%s].%u ", ia_str(from), sport);
 			fprintf(stderr, "[%s].%u ", ia_str(to), dport);
-			if (isdns && payload)
+			if ((flags & DNSCAP_OUTPUT_ISDNS) && payload)
 			    dump_dns(payload, payloadlen, stderr, "\\\n\t");
 		}
 		putc('\n', stderr);
@@ -2387,7 +2385,7 @@ output(const char *descr, iaddr from, iaddr to, uint8_t proto, int isfrag, int i
 	}
 	for (p = HEAD(plugins); p != NULL; p = NEXT(p, link))
 		if (p->output)
-			(*p->output)(descr, from, to, proto, isfrag, isdns, sport, dport, ts, pkt_copy, olen, payload, payloadlen);
+			(*p->output)(descr, from, to, proto, flags, sport, dport, ts, pkt_copy, olen, payload, payloadlen);
 	return;
 }
 

--- a/src/dnscap.c
+++ b/src/dnscap.c
@@ -1920,7 +1920,7 @@ network_pkt(const char *descr, my_bpftimeval ts, unsigned pf,
 			if (nexthdr == IPPROTO_FRAGMENT) {
 				if (wantfrags) {
 					flags |= DNSCAP_OUTPUT_ISFRAG;
-					output(descr, from, to, IPPROTO_FRAGMENT, flags, sport, dport, ts, pkt_copy, olen, pkt, len);
+					output(descr, from, to, IPPROTO_FRAGMENT, flags, sport, dport, ts, pkt_copy, olen, 0, 0);
 					return;
 				}
 				return;

--- a/src/dnscap.c
+++ b/src/dnscap.c
@@ -1870,7 +1870,7 @@ network_pkt(const char *descr, my_bpftimeval ts, unsigned pf,
 		{
 			if (wantfrags) {
 				flags |= DNSCAP_OUTPUT_ISFRAG;
-				output(descr, from, to, ip->ip_p, flags, sport, dport, ts, pkt_copy, olen, pkt, len);
+				output(descr, from, to, ip->ip_p, flags, sport, dport, ts, pkt_copy, olen, NULL, 0);
 				return;
 			}
 			return;
@@ -1920,7 +1920,7 @@ network_pkt(const char *descr, my_bpftimeval ts, unsigned pf,
 			if (nexthdr == IPPROTO_FRAGMENT) {
 				if (wantfrags) {
 					flags |= DNSCAP_OUTPUT_ISFRAG;
-					output(descr, from, to, IPPROTO_FRAGMENT, flags, sport, dport, ts, pkt_copy, olen, 0, 0);
+					output(descr, from, to, IPPROTO_FRAGMENT, flags, sport, dport, ts, pkt_copy, olen, NULL, 0);
 					return;
 				}
 				return;
@@ -2041,7 +2041,7 @@ network_pkt(const char *descr, my_bpftimeval ts, unsigned pf,
 		    if (dumptrace >= 3)
 			fprintf(stderr, "FIN|RST\n");
 		    output(descr, from, to, proto, flags, sport, dport, ts,
-			pkt_copy, olen, pkt, len);
+			pkt_copy, olen, NULL, 0);
 		    /* End of stream; deallocate the tcpstate. */
 		    if (tcpstate) {
 			UNLINK(tcpstates, tcpstate, link);
@@ -2055,7 +2055,7 @@ network_pkt(const char *descr, my_bpftimeval ts, unsigned pf,
 			fprintf(stderr, "SYN\n");
 		    /* Always output SYN segments. */
 		    output(descr, from, to, proto, flags, sport, dport, ts,
-			pkt_copy, olen, pkt, len);
+			pkt_copy, olen, NULL, 0);
 		    if (tcpstate) {
 #if 0
 			/* Disabled because warning may scare user, and
@@ -2105,7 +2105,7 @@ network_pkt(const char *descr, my_bpftimeval ts, unsigned pf,
 			tcpstate->dnslen = (pkt[0] << 8) | (pkt[1] << 0);
 			tcpstate->maxdiff = (uint32_t)len;
 			output(descr, from, to, proto, flags, sport, dport, ts,
-			    pkt_copy, olen, pkt, len);
+			    pkt_copy, olen, NULL, 0);
 			return;
 		    } else if ((seqdiff == 0 && len == 1) || seqdiff == 1) {
 			/* shouldn't happen */
@@ -2141,7 +2141,7 @@ network_pkt(const char *descr, my_bpftimeval ts, unsigned pf,
 			if (tcpstate->maxdiff < seqdiff + (uint32_t)len)
 			    tcpstate->maxdiff = seqdiff + (uint32_t)len;
 			output(descr, from, to, proto, flags, sport, dport, ts,
-			    pkt_copy, olen, pkt, len);
+			    pkt_copy, olen, NULL, 0);
 			return;
 		    }
 		} else {

--- a/src/dnscap_common.h
+++ b/src/dnscap_common.h
@@ -34,8 +34,7 @@ typedef void output_t(const char *descr,
         iaddr from,
         iaddr to,
         uint8_t proto,
-        int isfrag,
-	int isdns,
+        unsigned flags,
         unsigned sport,
         unsigned dport,
         my_bpftimeval ts,
@@ -43,6 +42,9 @@ typedef void output_t(const char *descr,
         const unsigned olen,
         const u_char *payload,
         const unsigned payloadlen);
+
+#define DNSCAP_OUTPUT_ISFRAG (1<<0)
+#define DNSCAP_OUTPUT_ISDNS (1<<1)
 
 #define DIR_INITIATE	0x0001
 #define DIR_RESPONSE	0x0002

--- a/src/dnscap_common.h
+++ b/src/dnscap_common.h
@@ -35,13 +35,14 @@ typedef void output_t(const char *descr,
         iaddr to,
         uint8_t proto,
         int isfrag,
+	int isdns,
         unsigned sport,
         unsigned dport,
         my_bpftimeval ts,
         const u_char *pkt_copy,
-        unsigned olen,
-        const u_char *dnspkt,
-        unsigned dnslen);
+        const unsigned olen,
+        const u_char *payload,
+        const unsigned payloadlen);
 
 #define DIR_INITIATE	0x0001
 #define DIR_RESPONSE	0x0002


### PR DESCRIPTION
This function has two args that point to packet data.  'pkt_copy'
points to the start of the full, raw packet that includes Ethernet,
IP, and transport headers.  The 'dnspkt' arg pointed to the start
of a DNS message, or may be NULL for non-DNS packets.

A problem arises with plugins that may want to access non-DNS
messages, such as ICMP.  With the old interface, a plugin that wants
ICMP payload would have to start with 'pkt_copy' and re-strip away
the Ethernet/IP headers, replicating code in the main dnscap program.

This change adds an 'isdns' flag to the family of output() functions.
It also renames 'dnspkt' to 'payload'.

When isdns is non-zero, payload points to the start of a DNS message.
It would be the caller's mistake to pass isdns=1 and payload=0.

When isdns is zero, and proto==ICMP, payload points to the start
of the ICMP header.