### PR TITLE
Extended options and CBOR output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,82 @@ Also note that we have observed significant memory leaks on FreeBSD
 1. de-select "Compile with thread support"
 1. reinstall the libbind port
 1. recompile and install dnscap
+
+## CBOR
+
+There is experimental support for CBOR output using LDNS and Tinycbor with
+a data structure described in the DNS-in-JSON draft.
+
+https://datatracker.ietf.org/doc/draft-hoffman-dns-in-json/
+
+### Enabling CBOR output
+
+To enable the CBOR output support you will need to install it's dependencies
+before running `configure`, LDNS exists for most distributions but Tinycbor
+is new so you need to download and compile it, you do not necessary need to
+install it as shown in the example below.
+
+```sh
+git clone https://github.com/DNS-OARC/dnscap.git
+cd dnscap
+git clone https://github.com/01org/tinycbor.git
+cd tinycbor
+make
+cd ..
+sh autogen.sh
+CFLAGS="-I$PWD/tinycbor/src" LDFLAGS="-L$PWD/tinycbor/lib" LIBS="-ltinycbor" ./configure
+make
+```
+
+**NOTE**: Paths in `CFLAGS` and `LDFLAGS` must be absolute.
+
+### CBOR to JSON
+
+Tinycbor comes with a tool to convert CBOR to JSON, check `bin/cbordump -h`
+in the Tinycbor directory after having compiled it.
+
+### Outputting to CBOR
+
+To output to the CBOR format you tell `dnscap` to write to a file and set
+the format to CBOR.  Since Tinycbor constructs everything in memory there
+is a limit and when it is reached it will write the output and start on a
+new file.  You can control the number of bytes with the extended option
+`cbor_chunk_size`.
+
+```
+src/dnscap -w <file> -F cbor [ -o cbor_chunk_size=<bytes>]
+```
+
+### Additional attributes
+
+There is currently an additional attribute added to the CBOR object which
+contains the IP information as following:
+
+```
+"ip": [
+  <proto>,
+  "<source ip address>",
+  <source port>
+  "<destination ip address>",
+  <destination port>
+]
+```
+
+Example:
+
+```json
+"ip": [
+  17,
+  "127.0.0.1",
+  34856,
+  "127.0.0.1",
+  53
+]
+```
+
+### Limitations, deviations and issues
+
+Since this is still experimental there are of course some issues:
+- RDATA is in binary format
+- DNS packet are parsed by LDNS which can fail if malformed packets
+- `dateSeconds` is added as a C `double` which might loose some of the time percision

--- a/configure.ac
+++ b/configure.ac
@@ -57,9 +57,10 @@ AC_CHECK_LIB([resolv], [res_mkquery], [], [
 	])
 ])
 AC_CHECK_LIB([dl], [dlopen])
-have_ldns=
-AC_CHECK_LIB([ldns], [ldns_wire2pkt], [have_ldns=yes])
-AM_CONDITIONAL([LDNS], [test "x$have_ldns" = "xyes"])
+AC_CHECK_LIB([tinycbor], [cbor_parser_init])
+AM_CONDITIONAL([HAVE_CBOR], [test "x$ac_cv_lib_tinycbor_cbor_parser_init" = "xyes"])
+AC_CHECK_LIB([ldns], [ldns_wire2pkt])
+AM_CONDITIONAL([HAVE_LDNS], [test "x$ac_cv_lib_ldns_ldns_wire2pkt" = "xyes"])
 
 # Check for OS specific libraries
 case "$host_os" in
@@ -81,7 +82,7 @@ esac
 AC_HEADER_RESOLV
 AC_CHECK_HEADERS([arpa/inet.h fcntl.h netdb.h netinet/in.h stdlib.h string.h])
 AC_CHECK_HEADERS([sys/ioctl.h sys/param.h sys/socket.h sys/time.h unistd.h])
-AC_CHECK_HEADERS([ldns/ldns.h arpa/nameser_compat.h])
+AC_CHECK_HEADERS([ldns/ldns.h arpa/nameser_compat.h cbor.h cbor/cbor.h])
 
 # Checks for library functions.
 AC_CHECK_FUNCS([snprintf])

--- a/plugins/rssm/Makefile.am
+++ b/plugins/rssm/Makefile.am
@@ -5,10 +5,9 @@ AM_CFLAGS = -I$(srcdir) \
     -I$(top_srcdir)/isc \
     $(SECCOMPFLAGS)
 
-if LDNS
+if HAVE_LDNS
 pkglib_LTLIBRARIES = rssm.la
 rssm_la_SOURCES = rssm.c hashtbl.c
 dist_rssm_la_SOURCES = hashtbl.h
 rssm_la_LDFLAGS = -module -avoid-version
-rssm_la_LIBADD = -lldns
 endif

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -12,10 +12,15 @@ bin_PROGRAMS = dnscap
 
 dnscap_SOURCES = dnscap.c \
     dump_dns.c \
-    pcap-thread/pcap_thread.c
-dist_dnscap_SOURCES = dnscap_common.h \
+    dump_cbor.c \
+    pcap-thread/pcap_thread.c \
+    options.c
+dist_dnscap_SOURCES = dnscap.h \
+    dnscap_common.h \
     dump_dns.h \
-    pcap-thread/pcap_thread.h
+    dump_cbor.h \
+    pcap-thread/pcap_thread.h \
+    options.h
 dnscap_LDADD = $(PTHREAD_LIBS)
 
 man1_MANS = dnscap.1

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -9,6 +9,12 @@
 /* Define to 1 if you have the <arpa/nameser.h> header file. */
 #undef HAVE_ARPA_NAMESER_H
 
+/* Define to 1 if you have the <cbor/cbor.h> header file. */
+#undef HAVE_CBOR_CBOR_H
+
+/* Define to 1 if you have the <cbor.h> header file. */
+#undef HAVE_CBOR_H
+
 /* Define to 1 if you have the <dlfcn.h> header file. */
 #undef HAVE_DLFCN_H
 
@@ -30,6 +36,9 @@
 /* Define to 1 if you have the `hplx' library (-lhplx). */
 #undef HAVE_LIBHPLX
 
+/* Define to 1 if you have the `ldns' library (-lldns). */
+#undef HAVE_LIBLDNS
+
 /* Define to 1 if you have the `md5' library (-lmd5). */
 #undef HAVE_LIBMD5
 
@@ -47,6 +56,9 @@
 
 /* Define to 1 if you have the `socket' library (-lsocket). */
 #undef HAVE_LIBSOCKET
+
+/* Define to 1 if you have the `tinycbor' library (-ltinycbor). */
+#undef HAVE_LIBTINYCBOR
 
 /* Define to 1 if you have the <memory.h> header file. */
 #undef HAVE_MEMORY_H

--- a/src/dnscap.1.in
+++ b/src/dnscap.1.in
@@ -7,6 +7,7 @@
 .Sh SYNOPSIS
 .Nm
 .Op Fl ?VbNpd1g6fTIySMD
+.Op Fl o Ar option=value
 .Op Fl i Ar if ...
 .Op Fl r Ar file ...
 .Op Fl l Ar vlan ...
@@ -71,6 +72,8 @@ won't have to refer back to this man page as often.  Probably you will have
 to say "-\\?" to get this option past your shell.
 .It Fl V
 Print version and exit.
+.It Fl o
+See EXTENDED OPTIONS.
 .It Fl b
 Run in background as daemon.
 .It Fl N
@@ -422,6 +425,23 @@ will also be tagged, thus we need
 on both
 .Nm
 commands.
+.Sh EXTENDED OPTIONS
+The following extended options exists and some of them might also exist
+as a short option.
+.Bl -tag -width 10n
+.It cbor_chunk_size=<bytes>
+Specify the number of bytes of CBOR to construct before flushing the output,
+must be a non zero positive number.
+.It dump_format=<format>
+Specify the output format to use, see OUTPUT FORMATS.
+.Sh OUTPUT FORMATS
+The following output format are supported:
+.Bl -tag -width 10n
+.It cbor
+Uses tinycbor library to write CBOR objects that are based on DNS-in-JSON
+draft by Paul Hoffman.
+.It pcap
+This uses the pcap library to output the captured DNS packets.
 .Sh "COMPATIBILITY NOTES"
 If
 .Nm dnscap

--- a/src/dnscap.h
+++ b/src/dnscap.h
@@ -32,59 +32,11 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <netinet/in.h>
-#include <sys/types.h>
+#include "dnscap_common.h"
 
-#ifndef __dnscap_dnscap_common_h
-#define __dnscap_dnscap_common_h
+#ifndef __dnscap_dnscap_h
+#define __dnscap_dnscap_h
 
-/*
- * setup MY_BPFTIMEVAL as the timeval structure that bpf packets
- * will be assoicated with packets from libpcap
- */
-#ifndef MY_BPFTIMEVAL
-# define MY_BPFTIMEVAL timeval
-#endif
-typedef struct MY_BPFTIMEVAL my_bpftimeval;
+const char *ia_str(iaddr);
 
-
-/*
- * Structure to contain IP addresses
- */
-typedef struct {
-        int                     af;
-        union {
-                struct in_addr          a4;
-                struct in6_addr         a6;
-        } u;
-} iaddr;
-
-/*
- * plugins can call the logerr() function in the main dnscap
- * process.
- */
-typedef int logerr_t(const char *fmt, ...);
-
-/*
- * Prototype for the plugin "output" function
- */
-typedef void output_t(const char *descr,
-        iaddr from,
-        iaddr to,
-        uint8_t proto,
-        unsigned flags,
-        unsigned sport,
-        unsigned dport,
-        my_bpftimeval ts,
-        const u_char *pkt_copy,
-        const unsigned olen,
-        const u_char *payload,
-        const unsigned payloadlen);
-
-#define DNSCAP_OUTPUT_ISFRAG (1<<0)
-#define DNSCAP_OUTPUT_ISDNS (1<<1)
-
-#define DIR_INITIATE	0x0001
-#define DIR_RESPONSE	0x0002
-
-#endif /* __dnscap_dnscap_common_h */
+#endif /* __dnscap_dnscap_h */

--- a/src/dump_cbor.c
+++ b/src/dump_cbor.c
@@ -1,0 +1,578 @@
+/*
+ * Copyright (c) 2016, OARC, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/*
+    DNS-in-JSON
+    - generally naming convention
+    - compressedNAME.length is there a point here? isn't the length in the
+      compressed data itself? Maybe have compressedNAME as just the data
+      of the compressed name
+    - 2.5 Additional Message Object Members
+      - IP stuff:
+        - ipProtocol: num
+        - sourceIpAddress: string
+        - sourcePort: num
+        - destinationIpAddress: string
+        - destinationPort: num
+        or
+        - ip: [ ipProtocol, sourceIpAddress, sourcePort, destinationIpAddress, destinationPort ]
+      - dateNanoFractions as addition to dateSeconds, specify the fraction of
+        nano seconds separatly to have better precision.
+*/
+
+#include "config.h"
+
+#include "dump_cbor.h"
+#include "dnscap.h"
+
+#if HAVE_LIBLDNS && HAVE_LIBTINYCBOR
+
+#include <ldns/ldns.h>
+#if HAVE_CBOR_CBOR_H
+#include <cbor/cbor.h>
+#endif
+#if HAVE_CBOR_H
+#include <cbor.h>
+#endif
+
+static uint8_t *cbor_buf = 0;
+static size_t cbor_size = 128*1024;
+/*static size_t cbor_size = 1024;*/
+static size_t cbor_reserve = 64*1024;
+static CborEncoder cbor_root, cbor_pkts;
+/*static cbor_stringref_t *cbor_stringrefs = 0;*/
+/*static size_t cbor_stringref_size = 8192;*/
+static int cbor_flushed = 1;
+
+int cbor_set_size(size_t size) {
+    if (!size) {
+        return DUMP_CBOR_EINVAL;
+    }
+
+    cbor_size = size;
+
+    return DUMP_CBOR_OK;
+}
+
+int cbor_set_reserve(size_t reserve) {
+    if (!reserve) {
+        return DUMP_CBOR_EINVAL;
+    }
+
+    cbor_reserve = reserve;
+
+    return DUMP_CBOR_OK;
+}
+
+#define append_cbor(func, name, type) CborError func(CborEncoder *encoder, type value, int *should_flush) { \
+    CborError err; \
+    uint8_t *ptr = encoder->ptr; \
+    err = name(encoder, value); \
+    if (err == CborErrorOutOfMemory && !*should_flush) { \
+        *should_flush = 1; \
+        encoder->ptr = ptr; \
+        encoder->end = cbor_buf + cbor_size + cbor_reserve; \
+        err = name(encoder, value); \
+    } \
+    return err; \
+}
+
+append_cbor(append_cbor_text_stringz, cbor_encode_text_stringz, const char *);
+append_cbor(append_cbor_boolean, cbor_encode_boolean, bool);
+append_cbor(append_cbor_int, cbor_encode_int, int64_t);
+append_cbor(append_cbor_uint, cbor_encode_uint, uint64_t);
+append_cbor(append_cbor_double, cbor_encode_double, double);
+
+CborError append_cbor_bytes(CborEncoder *encoder, uint8_t *bytes, size_t length, int *should_flush) {
+    CborError err;
+    uint8_t *ptr = encoder->ptr;
+    err = cbor_encode_byte_string(encoder, bytes, length);
+    if (err == CborErrorOutOfMemory && !*should_flush) {
+        *should_flush = 1;
+        encoder->ptr = ptr;
+        encoder->end = cbor_buf + cbor_size + cbor_reserve;
+        err = cbor_encode_byte_string(encoder, bytes, length);
+    }
+    return err;
+}
+
+/*CborError append_cbor_text_stringz2(CborEncoder *encoder, const char *value, int *should_flush) {*/
+/*    CborError err;*/
+/*    uint8_t *ptr = encoder->ptr;*/
+/*    err = cbor_encode_byte_string(encoder, bytes, length);*/
+/*    if (err == CborErrorOutOfMemory && !*should_flush) {*/
+/*        *should_flush = 1;*/
+/*        encoder->ptr = ptr;*/
+/*        encoder->end = cbor_buf + cbor_size + cbor_reserve;*/
+/*        err = cbor_encode_byte_string(encoder, bytes, length);*/
+/*    }*/
+/*    return err;*/
+/*}*/
+
+#define append_cbor_container(func, name) CborError func(CborEncoder *encoder, CborEncoder *container, size_t length, int *should_flush) { \
+    CborError err; \
+    uint8_t *ptr = encoder->ptr; \
+    err = name(encoder, container, length); \
+    if (err == CborErrorOutOfMemory && !*should_flush) { \
+        *should_flush = 1; \
+        encoder->ptr = ptr; \
+        encoder->end = cbor_buf + cbor_size + cbor_reserve; \
+        err = name(encoder, container, length); \
+    } \
+    return err; \
+}
+
+append_cbor_container(append_cbor_array, cbor_encoder_create_array);
+append_cbor_container(append_cbor_map, cbor_encoder_create_map);
+
+CborError close_cbor_container(CborEncoder *encoder, CborEncoder *container, int *should_flush) {
+    CborError err;
+    uint8_t *ptr = encoder->ptr;
+    err = cbor_encoder_close_container_checked(encoder, container);
+    if (err == CborErrorOutOfMemory && !*should_flush) {
+        *should_flush = 1;
+        encoder->ptr = ptr;
+        encoder->end = cbor_buf + cbor_size + cbor_reserve;
+        err = cbor_encoder_close_container_checked(encoder, container);
+    }
+    return err;
+}
+
+CborError cbor_ldns_rr_list(CborEncoder *encoder, ldns_rr_list *list, size_t count, int *should_flush) {
+    CborError cbor_err = CborNoError;
+    size_t n;
+    ldns_buffer *dname;
+    char *dname_str;
+
+    if (!encoder) {
+        return CborErrorInternalError;
+    }
+    if (!list) {
+        return CborErrorInternalError;
+    }
+    if (!count) {
+        return CborErrorInternalError;
+    }
+    if (!should_flush) {
+        return CborErrorInternalError;
+    }
+
+    for (n = 0; cbor_err == CborNoError && n < count; n++) {
+        CborEncoder cbor_rr;
+        uint8_t *rdata_bytes;
+        ldns_buffer *rdata;
+        ldns_rr *rr = ldns_rr_list_rr(list, n);
+        size_t rd_count;
+
+        if (!rr) {
+            return CborErrorInternalError;
+        }
+        rd_count = ldns_rr_rd_count(rr);
+
+        if (!(dname = ldns_buffer_new(512))) {
+            return CborErrorOutOfMemory;
+        }
+        if (ldns_rdf2buffer_str_dname(dname, ldns_rr_owner(rr)) != LDNS_STATUS_OK) {
+            ldns_buffer_free(dname);
+            return CborErrorInternalError;
+        }
+        ldns_buffer_write_u8(dname, 0);
+        if (!(dname_str = ldns_buffer_export(dname))) {
+            ldns_buffer_free(dname);
+            return CborErrorOutOfMemory;
+        }
+
+        if (cbor_err == CborNoError) cbor_err = append_cbor_map(encoder, &cbor_rr, CborIndefiniteLength, should_flush);
+        if (cbor_err == CborNoError) cbor_err = append_cbor_text_stringz(&cbor_rr, "NAME", should_flush);
+        if (cbor_err == CborNoError) cbor_err = append_cbor_text_stringz(&cbor_rr, dname_str, should_flush);
+        free(dname_str);
+        ldns_buffer_free(dname);
+        if (cbor_err == CborNoError) cbor_err = append_cbor_text_stringz(&cbor_rr, "CLASS", should_flush);
+        if (cbor_err == CborNoError) cbor_err = append_cbor_uint(&cbor_rr, ldns_rr_get_class(rr), should_flush);
+        if (cbor_err == CborNoError) cbor_err = append_cbor_text_stringz(&cbor_rr, "TYPE", should_flush);
+        if (cbor_err == CborNoError) cbor_err = append_cbor_uint(&cbor_rr, ldns_rr_get_type(rr), should_flush);
+        if (cbor_err == CborNoError) cbor_err = append_cbor_text_stringz(&cbor_rr, "TTL", should_flush);
+        if (cbor_err == CborNoError) cbor_err = append_cbor_uint(&cbor_rr, ldns_rr_ttl(rr), should_flush);
+
+        if (rd_count == 1) {
+            if (!(rdata = ldns_buffer_new(64*1024))) {
+                return CborErrorOutOfMemory;
+            }
+            if (ldns_rdf2buffer_wire(rdata, ldns_rr_rdf(rr, 0)) != LDNS_STATUS_OK) {
+                ldns_buffer_free(rdata);
+                return CborErrorInternalError;
+            }
+            if (!(rdata_bytes = ldns_buffer_export(rdata))) {
+                ldns_buffer_free(rdata);
+                return CborErrorOutOfMemory;
+            }
+
+            if (cbor_err == CborNoError) cbor_err = append_cbor_text_stringz(&cbor_rr, "RDLENGTH", should_flush);
+            if (cbor_err == CborNoError) cbor_err = append_cbor_uint(&cbor_rr, ldns_buffer_position(rdata), should_flush);
+            if (cbor_err == CborNoError) cbor_err = append_cbor_text_stringz(&cbor_rr, "RDATA", should_flush);
+            if (cbor_err == CborNoError) cbor_err = append_cbor_bytes(&cbor_rr, rdata_bytes, ldns_buffer_position(rdata), should_flush);
+            free(rdata_bytes);
+            ldns_buffer_free(rdata);
+        }
+        else if (rd_count > 1) {
+            size_t n2;
+            CborEncoder rr_set;
+
+            if (cbor_err == CborNoError) cbor_err = append_cbor_text_stringz(&cbor_rr, "rrSet", should_flush);
+            if (cbor_err == CborNoError) cbor_err = append_cbor_array(&cbor_rr, &rr_set, CborIndefiniteLength, should_flush);
+            for (n2 = 0; n2 < rd_count; n2++) {
+                if (!(rdata = ldns_buffer_new(64*1024))) {
+                    return CborErrorOutOfMemory;
+                }
+                if (ldns_rdf2buffer_wire(rdata, ldns_rr_rdf(rr, n2)) != LDNS_STATUS_OK) {
+                    ldns_buffer_free(rdata);
+                    return CborErrorInternalError;
+                }
+                if (!(rdata_bytes = ldns_buffer_export(rdata))) {
+                    ldns_buffer_free(rdata);
+                    return CborErrorOutOfMemory;
+                }
+
+                if (cbor_err == CborNoError) cbor_err = append_cbor_text_stringz(&rr_set, "RDLENGTH", should_flush);
+                if (cbor_err == CborNoError) cbor_err = append_cbor_uint(&rr_set, ldns_buffer_position(rdata), should_flush);
+                if (cbor_err == CborNoError) cbor_err = append_cbor_text_stringz(&rr_set, "RDATA", should_flush);
+                if (cbor_err == CborNoError) cbor_err = append_cbor_bytes(&rr_set, rdata_bytes, ldns_buffer_position(rdata), should_flush);
+                free(rdata_bytes);
+                ldns_buffer_free(rdata);
+            }
+            if (cbor_err == CborNoError) cbor_err = close_cbor_container(&cbor_rr, &rr_set, should_flush);
+        }
+
+        if (cbor_err == CborNoError) cbor_err = close_cbor_container(encoder, &cbor_rr, should_flush);
+    }
+
+    return cbor_err;
+}
+
+
+int output_cbor(iaddr from, iaddr to, uint8_t proto, unsigned flags, unsigned sport, unsigned dport, my_bpftimeval ts, const u_char *payload, size_t payloadlen) {
+    ldns_pkt *pkt = 0;
+    ldns_status ldns_rc;
+
+    if (!payload) {
+        return DUMP_CBOR_EINVAL;
+    }
+    if (!payloadlen) {
+        return DUMP_CBOR_EINVAL;
+    }
+
+/*    if (!cbor_stringrefs) {*/
+/*        cbor_stringrefs = calloc(1, cbor_stringref_size);*/
+/*    }*/
+    if (!cbor_buf) {
+        if (!(cbor_buf = calloc(1, cbor_size + cbor_reserve))) {
+            return DUMP_CBOR_ENOMEM;
+        }
+    }
+    if (cbor_flushed) {
+        CborError cbor_err;
+
+        cbor_encoder_init(&cbor_root, cbor_buf, cbor_size, 0);
+/*        cbor_err = cbor_encode_tag(&cbor_root, 256);*/
+/*        if (cbor_err == CborNoError)*/
+        cbor_err = cbor_encoder_create_array(&cbor_root, &cbor_pkts, CborIndefiniteLength);
+        if (cbor_err != CborNoError) {
+            fprintf(stderr, "cbor init error[%d]: %s\n", cbor_err, cbor_error_string(cbor_err));
+            return DUMP_CBOR_ECBOR;
+        }
+        cbor_flushed = 0;
+    }
+
+    ldns_rc = ldns_wire2pkt(&pkt, payload, payloadlen);
+
+    if (ldns_rc != LDNS_STATUS_OK) {
+        fprintf(stderr, "ldns error [%d]: %s\n", ldns_rc, ldns_get_errorstr_by_id(ldns_rc));
+        return DUMP_CBOR_ELDNS;
+    }
+    if (!pkt) {
+        return DUMP_CBOR_ELDNS;
+    }
+
+    CborEncoder cbor, ip;
+    CborError cbor_err = CborNoError;
+    int should_flush = 0;
+
+    cbor_err = append_cbor_map(&cbor_pkts, &cbor, CborIndefiniteLength, &should_flush);
+    if (cbor_err == CborNoError) cbor_err = append_cbor_text_stringz(&cbor, "dateSeconds", &should_flush);
+    if (cbor_err == CborNoError) cbor_err = append_cbor_double(&cbor, (double)ts.tv_sec + ( (double)ts.tv_usec / 1000000 ), &should_flush);
+/*            if (cbor_err == CborNoError) cbor_err = append_cbor_text_stringz(&cbor, "dateNanoFractions", &should_flush);*/
+/*            if (cbor_err == CborNoError) cbor_err = append_cbor_uint(&cbor, ts.tv_usec * 1000, &should_flush);*/
+
+    if (cbor_err == CborNoError) cbor_err = append_cbor_text_stringz(&cbor, "ip", &should_flush);
+/*            if (cbor_err == CborNoError) cbor_err = append_cbor_uint(&cbor, proto, &should_flush);*/
+/*            if (cbor_err == CborNoError) cbor_err = append_cbor_text_stringz(&cbor, "sourceIpAddress", &should_flush);*/
+/*            if (cbor_err == CborNoError) cbor_err = append_cbor_text_stringz(&cbor, ia_str(from), &should_flush);*/
+/*            if (cbor_err == CborNoError) cbor_err = append_cbor_text_stringz(&cbor, "sourcePort", &should_flush);*/
+/*            if (cbor_err == CborNoError) cbor_err = append_cbor_uint(&cbor, sport, &should_flush);*/
+/*            if (cbor_err == CborNoError) cbor_err = append_cbor_text_stringz(&cbor, "destinationIpAddress", &should_flush);*/
+/*            if (cbor_err == CborNoError) cbor_err = append_cbor_text_stringz(&cbor, ia_str(to), &should_flush);*/
+/*            if (cbor_err == CborNoError) cbor_err = append_cbor_text_stringz(&cbor, "destinationPort", &should_flush);*/
+/*            if (cbor_err == CborNoError) cbor_err = append_cbor_uint(&cbor, dport, &should_flush);*/
+
+    if (cbor_err == CborNoError) cbor_err = append_cbor_array(&cbor, &ip, CborIndefiniteLength, &should_flush);
+    if (cbor_err == CborNoError) cbor_err = append_cbor_uint(&ip, proto, &should_flush);
+    if (cbor_err == CborNoError) cbor_err = append_cbor_text_stringz(&ip, ia_str(from), &should_flush);
+    if (cbor_err == CborNoError) cbor_err = append_cbor_uint(&ip, sport, &should_flush);
+    if (cbor_err == CborNoError) cbor_err = append_cbor_text_stringz(&ip, ia_str(to), &should_flush);
+    if (cbor_err == CborNoError) cbor_err = append_cbor_uint(&ip, dport, &should_flush);
+    if (cbor_err == CborNoError) cbor_err = close_cbor_container(&cbor, &ip, &should_flush);
+
+    if (cbor_err == CborNoError) cbor_err = append_cbor_text_stringz(&cbor, "ID", &should_flush);
+    if (cbor_err == CborNoError) cbor_err = append_cbor_uint(&cbor, ldns_pkt_id(pkt), &should_flush);
+    if (cbor_err == CborNoError) cbor_err = append_cbor_text_stringz(&cbor, "QR", &should_flush);
+    if (cbor_err == CborNoError) cbor_err = append_cbor_boolean(&cbor, ldns_pkt_qr(pkt), &should_flush);
+    if (cbor_err == CborNoError) cbor_err = append_cbor_text_stringz(&cbor, "Opcode", &should_flush);
+    if (cbor_err == CborNoError) cbor_err = append_cbor_uint(&cbor, ldns_pkt_get_opcode(pkt), &should_flush);
+    if (cbor_err == CborNoError) cbor_err = append_cbor_text_stringz(&cbor, "AA", &should_flush);
+    if (cbor_err == CborNoError) cbor_err = append_cbor_boolean(&cbor, ldns_pkt_aa(pkt), &should_flush);
+    if (cbor_err == CborNoError) cbor_err = append_cbor_text_stringz(&cbor, "TC", &should_flush);
+    if (cbor_err == CborNoError) cbor_err = append_cbor_boolean(&cbor, ldns_pkt_tc(pkt), &should_flush);
+    if (cbor_err == CborNoError) cbor_err = append_cbor_text_stringz(&cbor, "RD", &should_flush);
+    if (cbor_err == CborNoError) cbor_err = append_cbor_boolean(&cbor, ldns_pkt_rd(pkt), &should_flush);
+    if (cbor_err == CborNoError) cbor_err = append_cbor_text_stringz(&cbor, "RA", &should_flush);
+    if (cbor_err == CborNoError) cbor_err = append_cbor_boolean(&cbor, ldns_pkt_ra(pkt), &should_flush);
+    if (cbor_err == CborNoError) cbor_err = append_cbor_text_stringz(&cbor, "AD", &should_flush);
+    if (cbor_err == CborNoError) cbor_err = append_cbor_boolean(&cbor, ldns_pkt_ad(pkt), &should_flush);
+    if (cbor_err == CborNoError) cbor_err = append_cbor_text_stringz(&cbor, "CD", &should_flush);
+    if (cbor_err == CborNoError) cbor_err = append_cbor_boolean(&cbor, ldns_pkt_cd(pkt), &should_flush);
+    if (cbor_err == CborNoError) cbor_err = append_cbor_text_stringz(&cbor, "RCODE", &should_flush);
+    if (cbor_err == CborNoError) cbor_err = append_cbor_uint(&cbor, ldns_pkt_get_rcode(pkt), &should_flush);
+    if (cbor_err == CborNoError) cbor_err = append_cbor_text_stringz(&cbor, "QDCOUNT", &should_flush);
+    if (cbor_err == CborNoError) cbor_err = append_cbor_uint(&cbor, ldns_pkt_qdcount(pkt), &should_flush);
+    if (cbor_err == CborNoError) cbor_err = append_cbor_text_stringz(&cbor, "ANCOUNT", &should_flush);
+    if (cbor_err == CborNoError) cbor_err = append_cbor_uint(&cbor, ldns_pkt_ancount(pkt), &should_flush);
+    if (cbor_err == CborNoError) cbor_err = append_cbor_text_stringz(&cbor, "NSCOUNT", &should_flush);
+    if (cbor_err == CborNoError) cbor_err = append_cbor_uint(&cbor, ldns_pkt_nscount(pkt), &should_flush);
+    if (cbor_err == CborNoError) cbor_err = append_cbor_text_stringz(&cbor, "ARCOUNT", &should_flush);
+    if (cbor_err == CborNoError) cbor_err = append_cbor_uint(&cbor, ldns_pkt_arcount(pkt), &should_flush);
+
+    /* questionRRs */
+
+    if (ldns_pkt_qdcount(pkt) > 0) {
+        ldns_rr_list *list = ldns_pkt_question(pkt);
+        ldns_rr *rr;
+        size_t n, qdcount = ldns_pkt_qdcount(pkt);
+        ldns_buffer *dname;
+        char *dname_str;
+
+        if (!list) {
+            ldns_pkt_free(pkt);
+            return DUMP_CBOR_ELDNS;
+        }
+        rr = ldns_rr_list_rr(list, 0);
+        if (!rr) {
+            ldns_pkt_free(pkt);
+            return DUMP_CBOR_ELDNS;
+        }
+
+        if (!(dname = ldns_buffer_new(512))) {
+            ldns_pkt_free(pkt);
+            return DUMP_CBOR_ENOMEM;
+        }
+        if (ldns_rdf2buffer_str_dname(dname, ldns_rr_owner(rr)) != LDNS_STATUS_OK) {
+            ldns_buffer_free(dname);
+            ldns_pkt_free(pkt);
+            return DUMP_CBOR_ELDNS;
+        }
+        ldns_buffer_write_u8(dname, 0);
+        if (!(dname_str = ldns_buffer_export(dname))) {
+            ldns_buffer_free(dname);
+            ldns_pkt_free(pkt);
+            return DUMP_CBOR_ENOMEM;
+        }
+
+        if (cbor_err == CborNoError) cbor_err = append_cbor_text_stringz(&cbor, "QNAME", &should_flush);
+        if (cbor_err == CborNoError) cbor_err = append_cbor_text_stringz(&cbor, dname_str, &should_flush);
+        free(dname_str);
+        ldns_buffer_free(dname);
+        if (cbor_err == CborNoError) cbor_err = append_cbor_text_stringz(&cbor, "QCLASS", &should_flush);
+        if (cbor_err == CborNoError) cbor_err = append_cbor_uint(&cbor, ldns_rr_get_class(rr), &should_flush);
+        if (cbor_err == CborNoError) cbor_err = append_cbor_text_stringz(&cbor, "QTYPE", &should_flush);
+        if (cbor_err == CborNoError) cbor_err = append_cbor_uint(&cbor, ldns_rr_get_type(rr), &should_flush);
+
+        if (qdcount > 1) {
+            CborEncoder queries;
+
+            if (cbor_err == CborNoError) cbor_err = append_cbor_text_stringz(&cbor, "questionRRs", &should_flush);
+            if (cbor_err == CborNoError) cbor_err = append_cbor_array(&cbor, &queries, CborIndefiniteLength, &should_flush);
+            for (n = 1; cbor_err == CborNoError && n < qdcount; n++) {
+                CborEncoder query;
+
+                rr = ldns_rr_list_rr(list, n);
+                if (!rr) {
+                    ldns_pkt_free(pkt);
+                    return DUMP_CBOR_ELDNS;
+                }
+
+                if (!(dname = ldns_buffer_new(512))) {
+                    ldns_pkt_free(pkt);
+                    return DUMP_CBOR_ENOMEM;
+                }
+                if (ldns_rdf2buffer_str_dname(dname, ldns_rr_owner(rr)) != LDNS_STATUS_OK) {
+                    ldns_buffer_free(dname);
+                    ldns_pkt_free(pkt);
+                    return DUMP_CBOR_ELDNS;
+                }
+                ldns_buffer_write_u8(dname, 0);
+                if (!(dname_str = ldns_buffer_export(dname))) {
+                    ldns_buffer_free(dname);
+                    ldns_pkt_free(pkt);
+                    return DUMP_CBOR_ENOMEM;
+                }
+
+                if (cbor_err == CborNoError) cbor_err = append_cbor_map(&queries, &query, CborIndefiniteLength, &should_flush);
+                if (cbor_err == CborNoError) cbor_err = append_cbor_text_stringz(&query, "NAME", &should_flush);
+                if (cbor_err == CborNoError) cbor_err = append_cbor_text_stringz(&query, dname_str, &should_flush);
+                free(dname_str);
+                ldns_buffer_free(dname);
+                if (cbor_err == CborNoError) cbor_err = append_cbor_text_stringz(&query, "CLASS", &should_flush);
+                if (cbor_err == CborNoError) cbor_err = append_cbor_uint(&query, ldns_rr_get_class(rr), &should_flush);
+                if (cbor_err == CborNoError) cbor_err = append_cbor_text_stringz(&query, "TYPE", &should_flush);
+                if (cbor_err == CborNoError) cbor_err = append_cbor_uint(&query, ldns_rr_get_type(rr), &should_flush);
+                if (cbor_err == CborNoError) cbor_err = close_cbor_container(&queries, &query, &should_flush);
+            }
+            if (cbor_err == CborNoError) cbor_err = close_cbor_container(&cbor, &queries, &should_flush);
+        }
+    }
+
+    /* answerRRs */
+
+    if (ldns_pkt_ancount(pkt) > 0) {
+        CborEncoder cbor_rrs;
+
+        if (cbor_err == CborNoError) cbor_err = append_cbor_text_stringz(&cbor, "answerRRs", &should_flush);
+        if (cbor_err == CborNoError) cbor_err = append_cbor_array(&cbor, &cbor_rrs, CborIndefiniteLength, &should_flush);
+        cbor_ldns_rr_list(&cbor_rrs, ldns_pkt_answer(pkt), ldns_pkt_ancount(pkt), &should_flush);
+        if (cbor_err == CborNoError) cbor_err = close_cbor_container(&cbor, &cbor_rrs, &should_flush);
+    }
+
+    /* authorityRRs */
+
+    if (ldns_pkt_nscount(pkt) > 0) {
+        CborEncoder cbor_rrs;
+
+        if (cbor_err == CborNoError) cbor_err = append_cbor_text_stringz(&cbor, "authorityRRs", &should_flush);
+        if (cbor_err == CborNoError) cbor_err = append_cbor_array(&cbor, &cbor_rrs, CborIndefiniteLength, &should_flush);
+        cbor_ldns_rr_list(&cbor_rrs, ldns_pkt_authority(pkt), ldns_pkt_nscount(pkt), &should_flush);
+        if (cbor_err == CborNoError) cbor_err = close_cbor_container(&cbor, &cbor_rrs, &should_flush);
+    }
+
+    /* additionalRRs */
+
+    if (ldns_pkt_arcount(pkt) > 0) {
+        CborEncoder cbor_rrs;
+
+        if (cbor_err == CborNoError) cbor_err = append_cbor_text_stringz(&cbor, "additionalRRs", &should_flush);
+        if (cbor_err == CborNoError) cbor_err = append_cbor_array(&cbor, &cbor_rrs, CborIndefiniteLength, &should_flush);
+        cbor_ldns_rr_list(&cbor_rrs, ldns_pkt_additional(pkt), ldns_pkt_arcount(pkt), &should_flush);
+        if (cbor_err == CborNoError) cbor_err = close_cbor_container(&cbor, &cbor_rrs, &should_flush);
+    }
+
+    ldns_pkt_free(pkt);
+
+    if (cbor_err == CborNoError) cbor_err = close_cbor_container(&cbor_pkts, &cbor, &should_flush);
+
+    if (cbor_err != CborNoError) {
+        fprintf(stderr, "cbor error[%d]: %s\n", cbor_err, cbor_error_string(cbor_err));
+        return DUMP_CBOR_ECBOR;
+    }
+
+    if (should_flush) {
+        if ((cbor_err = cbor_encoder_close_container_checked(&cbor_root, &cbor_pkts)) != CborNoError) {
+            fprintf(stderr, "cbor error[%d]: %s\n", cbor_err, cbor_error_string(cbor_err));
+            return DUMP_CBOR_ECBOR;
+        }
+
+        fprintf(stderr, "cbor output: %lu bytes\n", cbor_encoder_get_buffer_size(&cbor_root, cbor_buf));
+
+        cbor_flushed = 1;
+        return DUMP_CBOR_FLUSH;
+    }
+
+    return DUMP_CBOR_OK;
+}
+
+int dump_cbor(FILE * fp) {
+    CborError cbor_err;
+
+    if (!fp) {
+        return DUMP_CBOR_EINVAL;
+    }
+
+    if ((cbor_err = cbor_encoder_close_container_checked(&cbor_root, &cbor_pkts)) != CborNoError) {
+        fprintf(stderr, "cbor error[%d]: %s\n", cbor_err, cbor_error_string(cbor_err));
+        return DUMP_CBOR_ECBOR;
+    }
+
+    fprintf(stderr, "cbor output: %lu bytes\n", cbor_encoder_get_buffer_size(&cbor_root, cbor_buf));
+
+    if (fwrite(cbor_buf, cbor_encoder_get_buffer_size(&cbor_root, cbor_buf), 1, fp) != 1) {
+        return DUMP_CBOR_EWRITE;
+    }
+
+    return DUMP_CBOR_OK;
+}
+
+int have_cbor_support() {
+    return 1;
+}
+
+#else /* HAVE_LIBLDNS && HAVE_LIBTINYCBOR */
+
+int cbor_set_size(size_t size) {
+    return DUMP_CBOR_ENOSUP;
+}
+
+int cbor_set_reserve(size_t reserve) {
+    return DUMP_CBOR_ENOSUP;
+}
+
+int output_cbor(iaddr from, iaddr to, uint8_t proto, unsigned flags, unsigned sport, unsigned dport, my_bpftimeval ts, const u_char *payload, size_t payloadlen) {
+    return DUMP_CBOR_ENOSUP;
+}
+
+int dump_cbor() {
+    return DUMP_CBOR_ENOSUP;
+}
+
+int have_cbor_support() {
+    return 0;
+}
+
+#endif

--- a/src/dump_cbor.h
+++ b/src/dump_cbor.h
@@ -32,59 +32,32 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <netinet/in.h>
-#include <sys/types.h>
+#include "dnscap_common.h"
 
-#ifndef __dnscap_dnscap_common_h
-#define __dnscap_dnscap_common_h
+#ifndef __dnscap_dump_cbor_h
+#define __dnscap_dump_cbor_h
 
-/*
- * setup MY_BPFTIMEVAL as the timeval structure that bpf packets
- * will be assoicated with packets from libpcap
- */
-#ifndef MY_BPFTIMEVAL
-# define MY_BPFTIMEVAL timeval
-#endif
-typedef struct MY_BPFTIMEVAL my_bpftimeval;
-
+#define DUMP_CBOR_OK        0
+#define DUMP_CBOR_EINVAL    1
+#define DUMP_CBOR_ENOMEM    2
+#define DUMP_CBOR_ECBOR     3
+#define DUMP_CBOR_ELDNS     4
+#define DUMP_CBOR_EWRITE    5
+#define DUMP_CBOR_FLUSH     6
+#define DUMP_CBOR_ENOSUP    7
 
 /*
- * Structure to contain IP addresses
- */
-typedef struct {
-        int                     af;
-        union {
-                struct in_addr          a4;
-                struct in6_addr         a6;
-        } u;
-} iaddr;
+typedef struct cbor_stringref cbor_stringref_t;
+struct cbor_stringref {
+    char *string;
+    size_t ref;
+};
+*/
 
-/*
- * plugins can call the logerr() function in the main dnscap
- * process.
- */
-typedef int logerr_t(const char *fmt, ...);
+int cbor_set_size(size_t size);
+int cbor_set_reserve(size_t reserve);
+int output_cbor(iaddr from, iaddr to, uint8_t proto, unsigned flags, unsigned sport, unsigned dport, my_bpftimeval ts, const u_char *payload, size_t payloadlen);
+int dump_cbor();
+int have_cbor_support();
 
-/*
- * Prototype for the plugin "output" function
- */
-typedef void output_t(const char *descr,
-        iaddr from,
-        iaddr to,
-        uint8_t proto,
-        unsigned flags,
-        unsigned sport,
-        unsigned dport,
-        my_bpftimeval ts,
-        const u_char *pkt_copy,
-        const unsigned olen,
-        const u_char *payload,
-        const unsigned payloadlen);
-
-#define DNSCAP_OUTPUT_ISFRAG (1<<0)
-#define DNSCAP_OUTPUT_ISDNS (1<<1)
-
-#define DIR_INITIATE	0x0001
-#define DIR_RESPONSE	0x0002
-
-#endif /* __dnscap_dnscap_common_h */
+#endif /* __dnscap_dump_cbor_h */

--- a/src/options.h
+++ b/src/options.h
@@ -32,59 +32,28 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <netinet/in.h>
 #include <sys/types.h>
 
-#ifndef __dnscap_dnscap_common_h
-#define __dnscap_dnscap_common_h
+#ifndef __dnscap_options_h
+#define __dnscap_options_h
 
-/*
- * setup MY_BPFTIMEVAL as the timeval structure that bpf packets
- * will be assoicated with packets from libpcap
- */
-#ifndef MY_BPFTIMEVAL
-# define MY_BPFTIMEVAL timeval
-#endif
-typedef struct MY_BPFTIMEVAL my_bpftimeval;
+typedef enum dump_format dump_format_t;
+enum dump_format {
+    pcap,
+    cbor
+};
 
+#define OPTIONS_T_DEFAULTS { \
+    1024 * 1024, \
+    pcap \
+}
 
-/*
- * Structure to contain IP addresses
- */
-typedef struct {
-        int                     af;
-        union {
-                struct in_addr          a4;
-                struct in6_addr         a6;
-        } u;
-} iaddr;
+typedef struct options options_t;
+struct options {
+    size_t          cbor_chunk_size;
+    dump_format_t   dump_format;
+};
 
-/*
- * plugins can call the logerr() function in the main dnscap
- * process.
- */
-typedef int logerr_t(const char *fmt, ...);
+int option_parse(options_t * options, const char * option);
 
-/*
- * Prototype for the plugin "output" function
- */
-typedef void output_t(const char *descr,
-        iaddr from,
-        iaddr to,
-        uint8_t proto,
-        unsigned flags,
-        unsigned sport,
-        unsigned dport,
-        my_bpftimeval ts,
-        const u_char *pkt_copy,
-        const unsigned olen,
-        const u_char *payload,
-        const unsigned payloadlen);
-
-#define DNSCAP_OUTPUT_ISFRAG (1<<0)
-#define DNSCAP_OUTPUT_ISDNS (1<<1)
-
-#define DIR_INITIATE	0x0001
-#define DIR_RESPONSE	0x0002
-
-#endif /* __dnscap_dnscap_common_h */
+#endif /* __dnscap_options_h */


### PR DESCRIPTION
- Add extended options `-o <option>=<value>` because we are running out of short options.
- Better handling of library checks and automake rules
- New option `-F <format>` to specify the format of the output in `-w`
- Add experimental CBOR output support
  - LDNS is used to parse the packets
  - Tinycbor is used to construct the CBOR output
  - DNS-in-JSON draft [1] for representing the objects
  - Check CBOR topic in README.md for more information

[1] https://datatracker.ietf.org/doc/draft-hoffman-dns-in-json/