### PR TITLE
Make the -X option work without requiring a -x option.

### DIFF
--- a/src/dnscap.1.in
+++ b/src/dnscap.1.in
@@ -290,7 +290,9 @@ options are provided, then DNS messages will only be selected if the
 printable representation of the QNAME or any RR matches at least one of the
 provided
 .Ar pat
-patterns.  See
+patterns.  For negative matching see
+.Fl X
+below.  See
 .Xr regex 3
 and
 .Xr re_format 7
@@ -299,9 +301,13 @@ for more information about extended regular expression syntax.
 If one or more
 .Fl X
 options are provided, then DNS messages matching these patterns will not
-be selected.  See the description of
+be selected.  See also the description of
 .Fl x
-above.
+above.  If both options are used then the message must first be matched by
+.Fl x
+and then not matched by all
+.Fl X
+regex.
 .It Fl y
 Enable Linux seccomp-bpf sandbox if available (compile option).
 .It Fl S

--- a/src/dnscap.1.in
+++ b/src/dnscap.1.in
@@ -302,19 +302,6 @@ options are provided, then DNS messages matching these patterns will not
 be selected.  See the description of
 .Fl x
 above.
-.Pp
-NOTE: for reasons lost to the mists of time, it seems that
-.Fl X
-only takes effect when
-.Fl x
-is also used.  If you use
-.Fl X
-alone, you'll get no output.  Thus, you should at least use "-x ."
-to initially match all queries and then exclude certain patterns with
-.Fl X.
-Users of the
-.Fl X
-option should be advised that this behavior could change in future versions.
 .It Fl y
 Enable Linux seccomp-bpf sandbox if available (compile option).
 .It Fl S


### PR DESCRIPTION
While it was documented in the `man` page, the fact that the `-X` option does not do anything unless some `-x` option is passed is counter-intuitive. Plus this is not documented in the help output, so anyone relying on that output to actually help in this case may be unpleasantly surprised. This happened to one of our engineers, so I decided to change the default behavior to match expected behavior.

This patch makes dnscap treat the case of having only `-X` options as if it was preceeded by "-x ." (match everything).

I tested it by doing ad-hoc command line runs and verifying the results. I don't know if there is a test suite or anything like that, but I didn't see one. I'm happy to create tests if that's a thing.