### PR TITLE
pcap-thread v2.0.0, disable threads, errors handling

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -47,7 +47,11 @@ m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
 LT_INIT([disable-static])
 
 # pcap_thread
-AX_PCAP_THREAD
+AC_ARG_ENABLE(threads,
+    [AS_HELP_STRING([--enable-threads],
+        [enable the usage of threads (default disabled)])],
+    [AX_PCAP_THREAD],
+    [AX_PCAP_THREAD_PCAP])
 
 # Checks for libraries.
 AC_CHECK_LIB([bind], [ns_initparse], [], [AC_CHECK_LIB([bind], [__ns_initparse])])

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -81,6 +81,9 @@
 /* Define to 1 if you have the `ns_sprintrr' function. */
 #undef HAVE_NS_SPRINTRR
 
+/* Define to 1 if you have the `pcap_activate' function. */
+#undef HAVE_PCAP_ACTIVATE
+
 /* Define to 1 if you have the `pcap_create' function. */
 #undef HAVE_PCAP_CREATE
 

--- a/src/dnscap.1.in
+++ b/src/dnscap.1.in
@@ -456,6 +456,11 @@ Specify the output format to use, see OUTPUT FORMATS.
 Specify the user to drop privileges to (default nobody).
 .It group=<group>
 Specify the group to drop privileges to (default nobody).
+.It pcap_buffer_size=<num>
+Set the
+.Xr pcap 3pcap
+buffer size to use when capturing packets, can be used too not miss packets
+during processing.
 .El
 .Sh OUTPUT FORMATS
 The following output format are supported:

--- a/src/options.c
+++ b/src/options.c
@@ -166,6 +166,13 @@ int option_parse(options_t * options, const char * option) {
             return 0;
         }
     }
+    else if (have("pcap_buffer_size")) {
+        s = strtoul(argument, &p, 0);
+        if (p && !*p && s > 0) {
+            options->pcap_buffer_size = s;
+            return 0;
+        }
+    }
 
     return 1;
 }

--- a/src/options.h
+++ b/src/options.h
@@ -62,6 +62,8 @@ enum dump_format {
     pcap, \
 \
     0, \
+    0, \
+\
     0 \
 }
 
@@ -83,6 +85,8 @@ struct options {
 
     char *          user;
     char *          group;
+
+    size_t          pcap_buffer_size;
 };
 
 int option_parse(options_t * options, const char * option);

--- a/src/test/test1.sh
+++ b/src/test/test1.sh
@@ -2,4 +2,11 @@
 
 ../dnscap -g -r dns.pcap.dist 2>dns.out
 
+osrel=`uname -s`
+if [ "$osrel" = "OpenBSD" ]; then
+    mv dns.out dns.out.old
+    grep -v "^dnscap.*WARNING.*symbol.*relink" dns.out.old > dns.out
+    rm dns.out.old
+fi
+
 diff dns.out "$srcdir/dns.gold"


### PR DESCRIPTION
- Update pcap-thread to v2.0.0
- Threads disabled by default, use `./configure --enable-threads` to enable
- Add `-o pcap_buffer_size=num` to set internal buffer in libpcap, can be used
  too not miss packets during processing
- Check/print errors during pcap-thread initializing