### PR TITLE
auto gzip for pcaps

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -95,7 +95,7 @@ AC_CHECK_HEADERS([zlib.h])
 # Checks for library functions.
 AC_CHECK_FUNCS([snprintf])
 AC_CHECK_FUNCS([setreuid setresuid setregid setresgid setegid seteuid])
-AC_CHECK_FUNCS([fopencookie gzopen])
+AC_CHECK_FUNCS([funopen fopencookie gzopen])
 AC_CHECK_FUNC([ns_initparse],
     [AC_DEFINE([HAVE_NS_INITPARSE], [1], [Define to 1 if you have the `ns_initparse' function.])],
     [AC_CHECK_FUNC(__ns_initparse,

--- a/configure.ac
+++ b/configure.ac
@@ -65,6 +65,7 @@ AC_CHECK_LIB([tinycbor], [cbor_parser_init])
 AM_CONDITIONAL([HAVE_CBOR], [test "x$ac_cv_lib_tinycbor_cbor_parser_init" = "xyes"])
 AC_CHECK_LIB([ldns], [ldns_wire2pkt])
 AM_CONDITIONAL([HAVE_LDNS], [test "x$ac_cv_lib_ldns_ldns_wire2pkt" = "xyes"])
+AC_CHECK_LIB([z], [gzopen])
 
 # Check for OS specific libraries
 case "$host_os" in
@@ -89,10 +90,12 @@ AC_CHECK_HEADERS([arpa/inet.h fcntl.h netdb.h netinet/in.h stdlib.h string.h])
 AC_CHECK_HEADERS([sys/ioctl.h sys/param.h sys/socket.h sys/time.h unistd.h])
 AC_CHECK_HEADERS([ldns/ldns.h arpa/nameser_compat.h cbor.h cbor/cbor.h])
 AC_CHECK_HEADERS([sys/time.h])
+AC_CHECK_HEADERS([zlib.h])
 
 # Checks for library functions.
 AC_CHECK_FUNCS([snprintf])
 AC_CHECK_FUNCS([setreuid setresuid setregid setresgid setegid seteuid])
+AC_CHECK_FUNCS([fopencookie gzopen])
 AC_CHECK_FUNC([ns_initparse],
     [AC_DEFINE([HAVE_NS_INITPARSE], [1], [Define to 1 if you have the `ns_initparse' function.])],
     [AC_CHECK_FUNC(__ns_initparse,

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: net
 Priority: optional
 Maintainer: Jerry Lundström <lundstrom.jerry@gmail.com>
 Build-Depends: debhelper (>= 8.0.0), build-essential, automake, autoconf,
- libpcap-dev, netbase, libldns-dev, libtool
+ libpcap-dev, netbase, libldns-dev, libtool, zlib1g-dev
 Standards-Version: 3.9.4
 Homepage: https://www.dns-oarc.net/tools/dnscap
 Vcs-Git: https://github.com/DNS-OARC/dnscap.git

--- a/rpm/spec
+++ b/rpm/spec
@@ -12,6 +12,7 @@ Source0:        %{name}_%{version}.orig.tar.gz
 BuildRequires:  libpcap-devel
 BuildRequires:  ldns-devel
 BuildRequires:  openssl-devel
+BuildRequires:  zlib-devel
 BuildRequires:  autoconf
 BuildRequires:  automake
 BuildRequires:  libtool

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -27,6 +27,9 @@
 /* Define to 1 if you have the `fopencookie' function. */
 #undef HAVE_FOPENCOOKIE
 
+/* Define to 1 if you have the `funopen' function. */
+#undef HAVE_FUNOPEN
+
 /* Define to 1 if you have the `gzopen' function. */
 #undef HAVE_GZOPEN
 
@@ -199,8 +202,7 @@
 /* Define to 1 if you have the `__assertion_failed' function. */
 #undef HAVE___ASSERTION_FAILED
 
-/* Define to the sub-directory in which libtool stores uninstalled libraries.
-   */
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
 #undef LT_OBJDIR
 
 /* Name of package */

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -18,8 +18,17 @@
 /* Define to 1 if you have the <dlfcn.h> header file. */
 #undef HAVE_DLFCN_H
 
+/* Define to 1 if you have the <endian.h> header file. */
+#undef HAVE_ENDIAN_H
+
 /* Define to 1 if you have the <fcntl.h> header file. */
 #undef HAVE_FCNTL_H
+
+/* Define to 1 if you have the `fopencookie' function. */
+#undef HAVE_FOPENCOOKIE
+
+/* Define to 1 if you have the `gzopen' function. */
+#undef HAVE_GZOPEN
 
 /* Define to 1 if you have the <inttypes.h> header file. */
 #undef HAVE_INTTYPES_H
@@ -59,6 +68,12 @@
 
 /* Define to 1 if you have the `tinycbor' library (-ltinycbor). */
 #undef HAVE_LIBTINYCBOR
+
+/* Define to 1 if you have the `z' library (-lz). */
+#undef HAVE_LIBZ
+
+/* Define to 1 if you have the <machine/endian.h> header file. */
+#undef HAVE_MACHINE_ENDIAN_H
 
 /* Define to 1 if you have the <memory.h> header file. */
 #undef HAVE_MEMORY_H
@@ -154,6 +169,9 @@
 /* Define to 1 if you have the <string.h> header file. */
 #undef HAVE_STRING_H
 
+/* Define to 1 if you have the <sys/endian.h> header file. */
+#undef HAVE_SYS_ENDIAN_H
+
 /* Define to 1 if you have the <sys/ioctl.h> header file. */
 #undef HAVE_SYS_IOCTL_H
 
@@ -174,6 +192,9 @@
 
 /* Define to 1 if you have the <unistd.h> header file. */
 #undef HAVE_UNISTD_H
+
+/* Define to 1 if you have the <zlib.h> header file. */
+#undef HAVE_ZLIB_H
 
 /* Define to 1 if you have the `__assertion_failed' function. */
 #undef HAVE___ASSERTION_FAILED

--- a/src/dnscap.1.in
+++ b/src/dnscap.1.in
@@ -228,7 +228,10 @@ and
 options affect the total duration of the capture, and not merely the size and
 time limits of each individual dump file.
 .It Fl W Ar suffix
-The provided suffix is added to the dump file name, e. g.: ".pcap"
+The provided suffix is added to the dump file name, e. g.: ".pcap".  If the
+suffix ends with ".gz" then files will be automatically gzip compressed.  If
+gzip compression is requested but not supported (i.e. because of lack of
+system support) an error will be generated.
 .It Fl k Ar cmd
 After each dump file specified by
 .Fl w

--- a/src/dnscap.c
+++ b/src/dnscap.c
@@ -384,6 +384,7 @@ static int immediate_mode = FALSE;
 static int background = FALSE;
 static char errbuf[PCAP_ERRBUF_SIZE];
 static int v6bug = FALSE;
+static int wantgzip = FALSE;
 static int wantfrags = FALSE;
 static int wanticmp = FALSE;
 static int wanttcp = FALSE;
@@ -843,6 +844,21 @@ help_2(void) {
 }
 
 static void
+check_gzip() {
+	char *dot = strrchr(dump_suffix, '.');
+	if (dot) {
+		wantgzip = (strcmp(dot, ".gz") == 0) ? TRUE : FALSE;
+	}
+
+#if ! ( HAVE_GZOPEN && (HAVE_FUNOPEN || HAVE_FOPENCOOKIE ))
+	if (wantgzip) {
+		fprintf(stderr, "error: gzip compression requested but not supported\n");
+		exit(1);
+	}
+#endif
+}
+
+static void
 parse_args(int argc, char *argv[]) {
 	mypcap_ptr mypcap;
 	unsigned long ul;
@@ -1045,6 +1061,7 @@ parse_args(int argc, char *argv[]) {
 		    if (dump_suffix)
 		        free(dump_suffix);
 			dump_suffix = strdup(optarg);
+			check_gzip();
 			break;
 		case 'k':
 			if (dump_type != to_file)
@@ -2963,54 +2980,63 @@ daemonize(void)
   logerr("Backgrounded as pid %u", getpid());
 }
 
+#if HAVE_ZLIB_H
+#if HAVE_FUNOPEN
+static int
+gzip_cookie_write(void *cookie, const char *buf, int size) {
+	return gzwrite((gzFile)cookie, (voidpc)buf, (unsigned) size);
+}
+#elif HAVE_FOPENCOOKIE
 static ssize_t
 gzip_cookie_write(void *cookie, const char *buf, size_t size) {
-	return gzwrite((gzFile)cookie, (const void *)buf, (unsigned) size);
+	return gzwrite((gzFile)cookie, (voidpc)buf, (unsigned) size);
 }
+#endif
 
+#if HAVE_FUNOPEN || HAVE_FOPENCOOKIE
 static int
 gzip_cookie_close(void *cookie)
 {
 	return gzclose((gzFile)cookie);
 }
+#endif
+
+#if HAVE_FOPENCOOKIE
+static cookie_io_functions_t cookiefuncs = {
+	NULL, gzip_cookie_write, NULL, gzip_cookie_close
+};
+#endif
+
+#endif /* HAVE_ZLIB_H */
 
 static pcap_dumper_t *
 dnscap_pcap_dump_open(pcap_t *pcap, const char *path)
 {
-	static cookie_io_functions_t cookiefuncs = {
-		NULL, gzip_cookie_write, NULL, gzip_cookie_close
-	};
-
-	int compress = FALSE;
-	if (dump_suffix) {
-		char *dot = strrchr(dump_suffix, '.');
-		if (dot) {
-			compress = (strcmp(dot, ".gz") == 0) ? TRUE : FALSE;
-		}
-	}
-
-	if (compress) {
-#if defined(HAVE_GZOPEN) && defined (HAVE_FOPENCOOKIE)
+#if HAVE_GZOPEN
+	if (wantgzip) {
 		FILE *fp = NULL;
 		gzFile z = gzopen(path, "w");
-
 		if (z == NULL) {
 			perror("gzopen");
 			return NULL;
 		}
 
+#if HAVE_FUNOPEN
+		fp = funopen(z, NULL, gzip_cookie_write, NULL, gzip_cookie_close);
+		if (fp == NULL) {
+			perror("funopen");
+			return NULL;
+		}
+#elif HAVE_FOPENCOOKIE
 		fp = fopencookie(z, "w", cookiefuncs);
 		if (fp == NULL) {
 			perror("fopencookie");
 			return NULL;
 		}
-
-		return pcap_dump_fopen(pcap, fp);
-#else
-		fprintf(stderr, "warning: gzip compression requested but not supported");
-		/* falls-through */
 #endif
+		return pcap_dump_fopen(pcap, fp);
 	}
+#endif /* HAVE_GZOPEN */
 
 	return pcap_dump_open(pcap, path);
 }


### PR DESCRIPTION
- improved to use `funopen` on earlier BSD variants that don't include `fopencookie`
- conditional compilation macros should be safer now on systems without the relevant libraries
- fatal error generated if gzip is requested on a build that doesn't support it
- update to the manpage