### PR TITLE
Added -s to txtout for short output

### DIFF
--- a/plugins/txtout/txtout.c
+++ b/plugins/txtout/txtout.c
@@ -48,7 +48,6 @@
 #include "dnscap_common.h"
 
 static logerr_t* logerr;
-static int       opt_f = 0;
 static char*     opt_o = 0;
 static int       opt_s = 0;
 static FILE*     out   = 0;
@@ -59,7 +58,6 @@ void txtout_usage()
 {
     fprintf(stderr,
         "\ntxtout.so options:\n"
-        "\t-f         flag option\n"
         "\t-o <arg>   output file name\n"
         "\t-s         short output, only QTYPE/QNAME for IN\n");
 }
@@ -71,11 +69,8 @@ void txtout_getopt(int* argc, char** argv[])
      * process plugin options.
      */
     int c;
-    while ((c = getopt(*argc, *argv, "fso:")) != EOF) {
+    while ((c = getopt(*argc, *argv, "so:")) != EOF) {
         switch (c) {
-        case 'f':
-            opt_f = 1;
-            break;
         case 'o':
             if (opt_o)
                 free(opt_o);


### PR DESCRIPTION
This adds a "-s" option to the txtout plugin, so that the output is
```
A img.stb.s-msn.com
NS .
AAAA dns.anycastns1.org
```
instead of
```
1492079100.069621 185.29.87.230 50613 192.203.230.10 53 17 60849 0 0 | IN A img.stb.s-msn.com
1492079100.071583 213.180.142.148 7480 192.203.230.10 53 17 27368 0 0 | IN NS .
1492079100.073108 31.135.161.126 15680 192.203.230.10 53 17 9533 0 0 |CD| IN AAAA dns.anycastns1.org
```