### PR TITLE
Fix #105: `inet_ntop` buffers

### DIFF
--- a/plugins/rssm/rssm.c
+++ b/plugins/rssm/rssm.c
@@ -100,17 +100,6 @@ struct {
     my_hashtbl sources;
 } counts;
 
-static char*
-iaddr_ntop(const iaddr* ia)
-{
-    static char bufs[10][256];
-    static int  idx = 0;
-    if (10 == idx)
-        idx = 0;
-    inet_ntop(ia->af, &ia->u, bufs[idx], 256);
-    return bufs[idx];
-}
-
 static unsigned int
 iaddr_hash(const void* key)
 {
@@ -140,6 +129,17 @@ iaddr_cmp(const void* _a, const void* _b)
     if (a->af < b->af)
         return -1;
     return 1;
+}
+
+ia_str_t ia_str = 0;
+
+void rssm_extension(int ext, void* arg)
+{
+    switch (ext) {
+    case DNSCAP_EXT_IA_STR:
+        ia_str = (ia_str_t)arg;
+        break;
+    }
 }
 
 void rssm_usage()
@@ -268,7 +268,7 @@ void rssm_save_sources(const char* sbuf)
         return;
     }
     for (i = 0; i < counts.sources.num_addrs; i++) {
-        fprintf(fp, "%s %" PRIu64 "\n", iaddr_ntop(&counts.sources.addrs[i]), counts.sources.count[i]);
+        fprintf(fp, "%s %" PRIu64 "\n", ia_str(counts.sources.addrs[i]), counts.sources.count[i]);
     }
     fclose(fp);
     free(tbuf);

--- a/plugins/txtout/txtout.c
+++ b/plugins/txtout/txtout.c
@@ -140,13 +140,15 @@ int txtout_close(my_bpftimeval ts)
     return 0;
 }
 
-static const char*
-ia_str(iaddr ia)
-{
-    static char ret[sizeof "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"];
+ia_str_t ia_str = 0;
 
-    (void)inet_ntop(ia.af, &ia.u, ret, sizeof ret);
-    return (ret);
+void txtout_extension(int ext, void* arg)
+{
+    switch (ext) {
+    case DNSCAP_EXT_IA_STR:
+        ia_str = (ia_str_t)arg;
+        break;
+    }
 }
 
 void txtout_output(const char* descr, iaddr from, iaddr to, uint8_t proto, unsigned flags,

--- a/src/iaddr.c
+++ b/src/iaddr.c
@@ -38,10 +38,20 @@
 
 const char* ia_str(iaddr ia)
 {
-    static char ret[sizeof "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"];
+    static char inet[INET_ADDRSTRLEN], inet6[INET6_ADDRSTRLEN];
 
-    (void)inet_ntop(ia.af, &ia.u, ret, sizeof ret);
-    return (ret);
+    switch (ia.af) {
+    case AF_INET:
+        if (inet_ntop(ia.af, &ia.u, inet, sizeof(inet)))
+            return inet;
+        return "255.255.255.255";
+    case AF_INET6:
+        if (inet_ntop(ia.af, &ia.u, inet6, sizeof(inet6)))
+            return inet6;
+        return "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff";
+    }
+
+    return "UNKNOWN";
 }
 
 int ia_equal(iaddr x, iaddr y)


### PR DESCRIPTION
- Change `ia_str()` to use buffers with correct sizes, thanks to @RoyArends
  for spotting this!
- Use `ia_str` extension in `txtout` and `rssm` plugin
- Remove `iaddr_ntop` from `rssm` plugin, the buffers where not really used
  since `idx` was never changed