### PR TITLE
Don't discard tcpstate on a "too small" packet.

### DIFF
--- a/src/network.c
+++ b/src/network.c
@@ -662,9 +662,7 @@ void network_pkt(const char* descr, my_bpftimeval ts, unsigned pf,
     /* Application. */
     if (dnslen < sizeof dns) {
         if (dumptrace >= 3)
-            fprintf(stderr, "payload is smaller than a valid DNS message\n");
-        /* Just return; don't discard state.  A TCP packet that is
-         * "too small" should not discard all connection state. */
+            fprintf(stderr, "payload is smaller than a valid DNS header\n");
         return;
     }
     memcpy(&dns, dnspkt, sizeof dns);

--- a/src/network.c
+++ b/src/network.c
@@ -661,7 +661,10 @@ void network_pkt(const char* descr, my_bpftimeval ts, unsigned pf,
 
     /* Application. */
     if (dnslen < sizeof dns) {
-        discard(tcpstate, "too small");
+        if (dumptrace >= 3)
+            fprintf(stderr, "payload is smaller than a valid DNS message\n");
+        /* Just return; don't discard state.  A TCP packet that is
+         * "too small" should not discard all connection state. */
         return;
     }
     memcpy(&dns, dnspkt, sizeof dns);


### PR DESCRIPTION
Previously if a "too small" packet was found in a TCP conversation
(such as a lone ACK from client to server) the tcpstate was discarded,
which meant that all subsequent packets on the conversation would
be ignored.