### PR TITLE
CBOR/CDS and formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ cd dnscap
 git submodule update --init
 git clone https://github.com/01org/tinycbor.git
 cd tinycbor
-git checkout v0.4
+git checkout v0.4.2
 make
 cd ..
 sh autogen.sh

--- a/plugins/rzkeychange/rzkeychange.c
+++ b/plugins/rzkeychange/rzkeychange.c
@@ -354,7 +354,7 @@ int rzkeychange_close(my_bpftimeval ts)
     exit(0);
 }
 
-void rzkeychange_keytagsignal(const ldns_pkt *pkt, const ldns_rr* question_rr, iaddr addr)
+void rzkeychange_keytagsignal(const ldns_pkt* pkt, const ldns_rr* question_rr, iaddr addr)
 {
     ldns_rdf* qn;
     char*     qn_str = 0;

--- a/src/dump_cbor.c
+++ b/src/dump_cbor.c
@@ -55,6 +55,7 @@
 
 #include "dump_cbor.h"
 #include "dnscap.h"
+#include "iaddr.h"
 
 #if HAVE_LIBLDNS && HAVE_LIBTINYCBOR
 

--- a/src/dump_cds.c
+++ b/src/dump_cds.c
@@ -37,6 +37,7 @@
 #include "dump_cds.h"
 #include "dnscap.h"
 #include "hashtbl.h"
+#include "iaddr.h"
 
 #if HAVE_LIBTINYCBOR
 
@@ -279,9 +280,9 @@ static int check_dns_label(size_t* labels, uint8_t** p, size_t* l)
     return 0;
 }
 
-static unsigned int rdata_hash(const void* key)
+static unsigned int rdata_hash(const void* _item)
 {
-    const struct rdata* item = (const struct rdata*)k;
+    const struct rdata* item = (const struct rdata*)_item;
     size_t              n, o, p;
     unsigned int        key = 0;
 
@@ -301,7 +302,7 @@ static unsigned int rdata_hash(const void* key)
     return key;
 }
 
-static unsigned int rdata_cmp(const void* _a, const void* _b)
+static int rdata_cmp(const void* _a, const void* _b)
 {
     const struct rdata *a = (const struct rdata*)_a, *b = (const struct rdata*)_b;
 

--- a/src/options.h
+++ b/src/options.h
@@ -94,11 +94,11 @@ struct options {
 
     size_t pcap_buffer_size;
 
-    int use_layers;
-    int defrag_ipv4;
+    int    use_layers;
+    int    defrag_ipv4;
     size_t max_ipv4_fragments;
     size_t max_ipv4_fragments_per_packet;
-    int defrag_ipv6;
+    int    defrag_ipv6;
     size_t max_ipv6_fragments;
     size_t max_ipv6_fragments_per_packet;
 };


### PR DESCRIPTION
- Fix #120: Missed this while reworking hash table code
- Update instructions on tinycbor to v0.4.2
- Include for `ia_str()`
- Formatting code