### PR TITLE
Layers

### DIFF
--- a/plugins/pcapdump/pcapdump.c
+++ b/plugins/pcapdump/pcapdump.c
@@ -236,6 +236,8 @@ void pcapdump_output(const char* descr, iaddr from, iaddr to, uint8_t proto, uns
     const u_char* pkt_copy, const unsigned olen, const u_char* payload, const unsigned payloadlen)
 {
     struct pcap_pkthdr h;
+    if (flags & DNSCAP_OUTPUT_ISLAYER)
+        return;
     if (flags & DNSCAP_OUTPUT_ISDNS) {
         HEADER* dns = (HEADER*)payload;
         if (0 == dns->qr && 0 == (dir_wanted & DIR_INITIATE))

--- a/plugins/royparse/royparse.c
+++ b/plugins/royparse/royparse.c
@@ -242,6 +242,8 @@ void royparse_output(const char* descr, iaddr from, iaddr to, uint8_t proto, uns
             fprintf(r_out, "\n");
         } else if (opt_q != 0 && ns_msg_getflag(msg, ns_f_qr) == 0 && dport == 53) {
             struct pcap_pkthdr h;
+            if (flags & DNSCAP_OUTPUT_ISLAYER)
+                return;
             memset(&h, 0, sizeof h);
             h.ts  = ts;
             h.len = h.caplen = olen;

--- a/plugins/template/template.c
+++ b/plugins/template/template.c
@@ -133,5 +133,9 @@ void template_output(const char* descr, iaddr from, iaddr to, uint8_t proto, uns
      * packets were outputted.
      *
      * if flags & PCAP_OUTPUT_ISDNS != 0 then payload is the start of a DNS message.
+     *
+     * if flags & PCAP_OUTPUT_ISFRAG != 0 then the packet is a fragment.
+     *
+     * if flags & PCAP_OUTPUT_ISLAYER != 0 then the pkt_copy is the same as payload.
      */
 }

--- a/src/args.c
+++ b/src/args.c
@@ -576,6 +576,8 @@ void parse_args(int argc, char* argv[])
     }
     assert(msg_wanted != 0U);
     assert(err_wanted != 0U);
+    if (dump_type != nowhere && options.use_layers)
+        usage("use_layers is only compatible with -g so far");
     if (dump_type == nowhere && !preso && EMPTY(plugins))
         usage("without -w or -g, there would be no output");
     if (end_hide != 0U && wantfrags)


### PR DESCRIPTION
- `use_layers` does not work with other output then `-g`, yet
- Add description of other output states in example
- Ignore output for `pcapdump` and `royparse` if layers is used since
  they need the original packet