### PR TITLE
Fix fragments from different IPs getting caught by BPF

### DIFF
--- a/src/bpft.c
+++ b/src/bpft.c
@@ -67,13 +67,13 @@ void prepare_bpft(void)
     }
 
     /*
- * Model
- * (vlan) and (transport)
- * (vlan) and ((icmp) or (frags) or (dns))
- * (vlan) and ((icmp) or (frags) or ((ports) and (hosts)))
- * (vlan) and ((icmp) or (frags) or (((tcp) or (udp)) and (hosts)))
- * [(vlan) and] ( [(icmp) or] [(frags) or] ( ( [(tcp) or] (udp) ) [and (hosts)] ) )
- */
+     * Model
+     * (vlan) and (transport)
+     * (vlan) and ((icmp) or (frags) or (dns))
+     * (vlan) and ((icmp) or ((frags) or (ports) and (hosts)))
+     * (vlan) and ((icmp) or ((frags) or ((tcp) or (udp)) and (hosts)))
+     * [(vlan) and] ( [(icmp) or] ([(frags) or] ( [(tcp) or] (udp) ) [and (hosts)] ) )
+     */
 
     /* Make a BPF program to do early course kernel-level filtering. */
     INIT_LIST(bpfl);
@@ -84,11 +84,11 @@ void prepare_bpft(void)
     if (wanticmp) {
         len += text_add(&bpfl, "( ip proto 1 or ip proto 58 ) or ");
     }
+    len += text_add(&bpfl, "( "); /* ( dns ...  */
+    len += text_add(&bpfl, "( "); /* ( ports ...  */
     if (wantfrags) {
         len += text_add(&bpfl, "( ip[6:2] & 0x1fff != 0 or ip6[6] = 44 ) or ");
     }
-    len += text_add(&bpfl, "( "); /* ( dns ...  */
-    len += text_add(&bpfl, "( "); /* ( ports ...  */
     if (wanttcp) {
         len += text_add(&bpfl, "( tcp port %d ) or ", dns_port);
         /* tcp packets can be filtered by initiators/responders, but


### PR DESCRIPTION
We noticed an issue where fragments from different IPs were getting caught by the BPF. This change causes fragments to be checked if they are related to the correct host.

Ex:
```
dnscap: "( ( ( ( ip[6:2] & 0x1fff != 0 or ip6[6] = 44 ) or ( tcp port 53 ) or ( udp port 53) ) and host ( 2001:500:a7::2 or 199.4.144.2 )) )"
```
instead of:
```
dnscap: "( ( ip[6:2] & 0x1fff != 0 or ip6[6] = 44 ) or ( ( ( tcp port 53 ) or ( udp port 53) )  and host ( 2001:500:a7::2 or 199.4.144.2 )) )"
```