### PR TITLE
RSSM RSSAC002v3 YAML Tool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ compiler:
   - gcc
 before_install:
   - sudo apt-get -qq update
-  - sudo apt-get install -y libpcap-dev libldns-dev libbind-dev
+  - sudo apt-get install -y libpcap-dev libldns-dev libbind-dev libyaml-perl
 install: ./autogen.sh
 script:
   - ./configure

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: net
 Priority: optional
 Maintainer: Jerry Lundström <lundstrom.jerry@gmail.com>
 Build-Depends: debhelper (>= 8.0.0), build-essential, automake, autoconf,
- libpcap-dev, netbase, libldns-dev, libtool, zlib1g-dev
+ libpcap-dev, netbase, libldns-dev, libtool, zlib1g-dev, libyaml-perl
 Standards-Version: 3.9.4
 Homepage: https://www.dns-oarc.net/tools/dnscap
 Vcs-Git: https://github.com/DNS-OARC/dnscap.git

--- a/debian/dnscap.install
+++ b/debian/dnscap.install
@@ -1,5 +1,7 @@
 usr/share/man/man1/dnscap.1
+usr/share/man/man1/dnscap-rssm-rssac002.1
 usr/bin/dnscap
+usr/bin/dnscap-rssm-rssac002
 usr/lib/dnscap/pcapdump.so
 usr/lib/dnscap/txtout.so
 usr/lib/dnscap/rssm.so

--- a/plugins/rssm/Makefile.am
+++ b/plugins/rssm/Makefile.am
@@ -13,8 +13,11 @@ rssm_la_SOURCES = rssm.c
 nodist_rssm_la_SOURCES = hashtbl.c
 BUILT_SOURCES = hashtbl.c
 rssm_la_LDFLAGS = -module -avoid-version
-TESTS = test1.sh
-EXTRA_DIST = $(TESTS) test1.gold
+TESTS = test1.sh test2.sh
+EXTRA_DIST = $(TESTS) test1.gold test2.gold dnscap-rssm-rssac002.1.in
+dist_bin_SCRIPTS = dnscap-rssm-rssac002
+man1_MANS = dnscap-rssm-rssac002.1
+CLEANFILES += test2.out $(man1_MANS)
 endif
 
 hashtbl.c: $(top_srcdir)/src/hashtbl.c
@@ -22,3 +25,9 @@ hashtbl.c: $(top_srcdir)/src/hashtbl.c
 
 $(srcdir)/hashtbl.c: $(top_srcdir)/src/hashtbl.c
 	cp $(top_srcdir)/src/hashtbl.c $(srcdir)/
+
+dnscap-rssm-rssac002.1: dnscap-rssm-rssac002.1.in Makefile
+	sed -e 's,[@]PACKAGE_VERSION[@],$(PACKAGE_VERSION),g' \
+        -e 's,[@]PACKAGE_URL[@],$(PACKAGE_URL),g' \
+        -e 's,[@]PACKAGE_BUGREPORT[@],$(PACKAGE_BUGREPORT),g' \
+        < $(srcdir)/dnscap-rssm-rssac002.1.in > dnscap-rssm-rssac002.1

--- a/plugins/rssm/README.md
+++ b/plugins/rssm/README.md
@@ -1,0 +1,41 @@
+# Root Server Scaling Measurement (RSSM) plugin
+
+This plugin collects data as described by the [RSSAC002v3 specification](https://www.icann.org/en/system/files/files/rssac-002-measurements-root-06jun16-en.pdf)
+which has been created by [ICANN Root Server System Advisory Committee](https://www.icann.org/groups/rssac) (RSSAC).
+
+## Additions
+
+As the RSSAC002v3 specification states that measurements should be saved per
+24 hours interval, this plugin produces additional metrics that can be used
+to compile the 24 hours measurements allowing for variable time between
+output generation.
+
+Metric `dnscap-rssm-sources` has a hash entry called `sources` which lists
+IP addresses and the number of times they appeared.
+
+Metric `dnscap-rssm-aggregated-sources` has a hash entry called `aggregated-sources`
+which lists the aggregated IPv6 addresses by a /64 net and the number of times
+it has appeared.
+
+## Merge Tool
+
+The Perl script `dnscap-rssm-rssac002` is included and installed with `dnscap`
+and can be used to multiple combine RSSM plugin RSSAC002v3 YAML output files
+into one file.
+
+The script will merge and remove metric specific to this plugin and replace
+others to fill in correct values for the new time period. The earliest
+`start-period` found will be used for all metrics.
+
+**NOTE** no parsing of `start-period` is performed, it is up to the operator
+to only give input files related to the same 24 hour period.
+
+Options:
+- `--no-recompile`: Disabled the combining of metrics and the removal of
+  metrics specific to this plugin
+- `--keep-dnscap-rssm`: Do the combining but keep the metrics specific to
+  this plugin
+- `--sort`: Output will always start with `version:`, `service:`,
+  `start-period:` and `metric:`, rest of the values are not ordered by label.
+  This option enabled sorting of them, which is not required by the
+  specification but may help in debugging and testing cases.

--- a/plugins/rssm/dnscap-rssm-rssac002
+++ b/plugins/rssm/dnscap-rssm-rssac002
@@ -1,0 +1,222 @@
+#!/usr/bin/env perl
+#
+# Copyright (c) 2018, OARC, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+use strict;
+use warnings;
+use YAML;
+
+unless (scalar @ARGV > 1) {
+    print "usage: dnscap-rssm-rssac002 [--no-recompile|--keep-dnscap-rssm|--sort] <YAML files to merge...>\n";
+    exit(1);
+}
+
+my %service = ();
+my $earliest_start_period;
+my $recompile = 1;
+my $keep_dnscap_rssm = 0;
+my $sort = 0;
+
+foreach my $file (@ARGV) {
+    if ($file eq '--no-recompile') {
+        $recompile = 0;
+        next;
+    } elsif ($file eq '--keep-dnscap-rssm') {
+        $keep_dnscap_rssm = 1;
+        next;
+    } elsif ($file eq '--sort') {
+        $sort = 1;
+        next;
+    }
+    foreach my $doc (YAML::LoadFile($file)) {
+        my $version = delete $doc->{version};
+        my $service = delete $doc->{service};
+        my $start_period = delete $doc->{'start-period'};
+        my $metric = delete $doc->{metric};
+        unless ($version) {
+            die "$file: not valid RSSAC002 YAML, missing version";
+        }
+        unless ($service) {
+            die "$file: not valid RSSAC002 YAML, missing service";
+        }
+        unless ($start_period) {
+            die "$file: not valid RSSAC002 YAML, missing start-period";
+        }
+        unless ($metric) {
+            die "$file: not valid RSSAC002 YAML, missing metric";
+        }
+        unless ($version eq 'rssac002v3') {
+            die "$file: unsupported RSSAC002 version $version";
+        }
+
+        push(@{$service{$service}->{$metric}}, $doc);
+
+        if (!$earliest_start_period or $start_period lt $earliest_start_period) {
+            $earliest_start_period = $start_period;
+        }
+    }
+}
+
+foreach my $service (keys %service) {
+    foreach my $metric (keys %{$service{$service}}) {
+        my %doc = ();
+        foreach (@{$service{$service}->{$metric}}) {
+            eval {
+                merge(\%doc, $_);
+            };
+            if ($@) {
+                die "service $service metric $metric: $@";
+            }
+        }
+        $service{$service}->{$metric} = \%doc;
+    }
+}
+
+if ($recompile) {
+    foreach my $service (keys %service) {
+        my ($ipv4, $ipv6, $aggregated) = (0, 0, 0);
+        my $metric;
+
+        if ($keep_dnscap_rssm) {
+            $metric = $service{$service}->{'dnscap-rssm-sources'};
+        } else {
+            $metric = delete $service{$service}->{'dnscap-rssm-sources'};
+        }
+        if ($metric) {
+            if (ref($metric->{sources}) eq 'HASH') {
+                foreach my $ip (keys %{$metric->{sources}}) {
+                    if ($ip =~ /:/o) {
+                        $ipv6++;
+                    } else {
+                        $ipv4++;
+                    }
+                }
+            }
+        }
+
+        if ($keep_dnscap_rssm) {
+            $metric = $service{$service}->{'dnscap-rssm-aggregated-sources'};
+        } else {
+            $metric = delete $service{$service}->{'dnscap-rssm-aggregated-sources'};
+        }
+        if ($metric) {
+            if (ref($metric->{'aggregated-sources'}) eq 'HASH') {
+                my @keys = keys %{$metric->{'aggregated-sources'}};
+                $aggregated += scalar @keys;
+            }
+        }
+
+        $service{$service}->{'unique-sources'} = {
+            'num-sources-ipv4' => $ipv4,
+            'num-sources-ipv6' => $ipv6,
+            'num-sources-ipv6-aggregate' => $aggregated,
+        };
+    }
+}
+
+# Produce RSSAC002v3 output outselves since it contains "quirks"
+if ($sort) {
+    foreach my $service (sort keys %service) {
+        foreach my $metric (sort keys %{$service{$service}}) {
+            print "---\n";
+            print "version: rssac002v3\n";
+            print "service: $service\n";
+            print "start-period: '$earliest_start_period'\n";
+            print "metric: $metric\n";
+            output($service{$service}->{$metric}, '');
+            print "\n";
+        }
+    }
+} else {
+    foreach my $service (keys %service) {
+        foreach my $metric (keys %{$service{$service}}) {
+            print "---\n";
+            print "version: rssac002v3\n";
+            print "service: $service\n";
+            print "start-period: '$earliest_start_period'\n";
+            print "metric: $metric\n";
+            output($service{$service}->{$metric}, '');
+            print "\n";
+        }
+    }
+}
+
+sub output {
+    my ( $doc, $indent ) = @_;
+    my @keys;
+    if ($sort) {
+        @keys = sort {
+            if ($a =~ /^\d+\-\d+$/o) {
+                my ($aa) = split(/\-/o, $a, 2);
+                my ($bb) = split(/\-/o, $b, 2);
+                $aa <=> $bb;
+            } else {
+                $a cmp $b;
+            }
+        } keys %$doc;
+    } else {
+        @keys = keys %$doc;
+    }
+    foreach my $key (@keys) {
+        if (ref($doc->{$key}) eq 'HASH') {
+            print $indent.$key.":\n";
+            output($doc->{$key}, $indent.'  ');
+        } else {
+            print $indent.$key.': '.(defined($doc->{$key})?$doc->{$key}:'')."\n";
+        }
+    }
+}
+
+sub merge {
+    my ( $doc, $measurements ) = @_;
+
+    foreach my $key (keys %$measurements) {
+        if (ref($doc->{$key}) eq 'HASH') {
+            unless (ref($measurements->{$key}) eq 'HASH') {
+                die "invalid measurement types for key $key: not a hash";
+            }
+            eval {
+                merge($doc->{$key}, $measurements->{$key});
+            };
+            die $@ if ($@);
+            next;
+        }
+        if (defined($doc->{$key})) {
+            if (defined($measurements->{$key}) and $measurements->{$key} ne '') {
+                $doc->{$key} += $measurements->{$key};
+            }
+        } else {
+            $doc->{$key} = $measurements->{$key};
+        }
+    }
+}

--- a/plugins/rssm/dnscap-rssm-rssac002.1.in
+++ b/plugins/rssm/dnscap-rssm-rssac002.1.in
@@ -1,0 +1,98 @@
+.\" Copyright (c) 2017-2018, OARC, Inc.
+.\" All rights reserved.
+.\"
+.\" Redistribution and use in source and binary forms, with or without
+.\" modification, are permitted provided that the following conditions
+.\" are met:
+.\"
+.\" 1. Redistributions of source code must retain the above copyright
+.\"    notice, this list of conditions and the following disclaimer.
+.\"
+.\" 2. Redistributions in binary form must reproduce the above copyright
+.\"    notice, this list of conditions and the following disclaimer in
+.\"    the documentation and/or other materials provided with the
+.\"    distribution.
+.\"
+.\" 3. Neither the name of the copyright holder nor the names of its
+.\"    contributors may be used to endorse or promote products derived
+.\"    from this software without specific prior written permission.
+.\"
+.\" THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+.\" "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+.\" LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+.\" FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+.\" COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+.\" INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+.\" BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+.\" LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+.\" CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+.\" LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+.\" ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+.\" POSSIBILITY OF SUCH DAMAGE.
+.\"
+.TH dnscap-rssm-rssac002 1 "dnscap-v@PACKAGE_VERSION@" "dnscap RSSAC002v3 Tool"
+.SH NAME
+dnscap-rssm-rssac002 \- Combine RSSAC002v3 YAML files
+.SH SYNOPSIS
+.B dnscap-rssm-rssac002
+[
+.B \--no-recompile
+.B \--keep-dnscap-rssm
+.B \--sort
+]
+.I files...
+.SH DESCRIPTION
+This Perl script will merge and remove metric specific to this plugin and
+replace others to fill in correct values for the new time period.
+The earliest
+.I start-period
+found will be used for all metrics.
+.LP
+.B NOTE
+no parsing of
+.I start-period
+is performed, it is up to the operator to only give input files related
+to the same 24 hour period.
+.SH OPTIONS
+.TP
+.B \--no-recompile
+Disabled the combining of metrics and the removal of metrics specific to
+this plugin.
+.TP
+.B \--keep-dnscap-rssm
+Do the combining but keep the metrics specific to this plugin.
+.TP
+.B \--sort
+Output will always start with
+.IR version: ,
+.IR service: ,
+.I start-period:
+and
+.IR metric: ,
+rest of the values are not ordered by label.
+This option enabled sorting of them, which is not required by the
+specification but may help in debugging and testing cases.
+.SH SEE ALSO
+.BR dnscap (1)
+.SH AUTHORS
+Jerry Lundström, DNS-OARC
+.LP
+Maintained by DNS-OARC
+.LP
+.RS
+.I https://www.dns-oarc.net/
+.RE
+.LP
+.SH BUGS
+For issues and feature requests please use:
+.LP
+.RS
+\fI@PACKAGE_URL@\fP
+.RE
+.LP
+For question and help please use:
+.LP
+.RS
+\fI@PACKAGE_BUGREPORT@\fP
+.RE
+.LP

--- a/plugins/rssm/test2.gold
+++ b/plugins/rssm/test2.gold
@@ -1,0 +1,44 @@
+---
+version: rssac002v3
+service: test1
+start-period: '2016-10-20T15:23:01Z'
+metric: rcode-volume
+0: 123
+
+---
+version: rssac002v3
+service: test1
+start-period: '2016-10-20T15:23:01Z'
+metric: traffic-sizes
+tcp-request-sizes: 
+tcp-response-sizes: 
+udp-request-sizes:
+  16-31: 72
+  32-47: 51
+udp-response-sizes:
+  176-191: 72
+  256-271: 51
+
+---
+version: rssac002v3
+service: test1
+start-period: '2016-10-20T15:23:01Z'
+metric: traffic-volume
+dns-tcp-queries-received-ipv4: 0
+dns-tcp-queries-received-ipv6: 0
+dns-tcp-responses-sent-ipv4: 0
+dns-tcp-responses-sent-ipv6: 0
+dns-udp-queries-received-ipv4: 123
+dns-udp-queries-received-ipv6: 0
+dns-udp-responses-sent-ipv4: 123
+dns-udp-responses-sent-ipv6: 0
+
+---
+version: rssac002v3
+service: test1
+start-period: '2016-10-20T15:23:01Z'
+metric: unique-sources
+num-sources-ipv4: 1
+num-sources-ipv6: 0
+num-sources-ipv6-aggregate: 0
+

--- a/plugins/rssm/test2.sh
+++ b/plugins/rssm/test2.sh
@@ -1,0 +1,5 @@
+#!/bin/sh -xe
+
+"$srcdir"/dnscap-rssm-rssac002 --sort "$srcdir/test1.gold" "$srcdir/test1.gold" "$srcdir/test1.gold" > test2.out
+
+diff test2.out "$srcdir/test2.gold"

--- a/rpm/dnscap.spec
+++ b/rpm/dnscap.spec
@@ -17,6 +17,7 @@ BuildRequires:  zlib-devel
 BuildRequires:  autoconf
 BuildRequires:  automake
 BuildRequires:  libtool
+BuildRequires:  perl-YAML
 
 %description
 dnscap is a network capture utility designed specifically for DNS


### PR DESCRIPTION
- Fix #94: Add `dnscap-rssm-rssac002` Perl script for merging RSSAC002v3 YAML files
- Add man-page for `dnscap-rssm-rssac002`
- Add README.md for RSSM plugin
- Add test for merging YAML files