### PR TITLE
Workaround for stdio mystery causing duplicate royparse output.

### DIFF
--- a/plugins/royparse/royparse.c
+++ b/plugins/royparse/royparse.c
@@ -122,6 +122,7 @@ int royparse_start(logerr_t* a_logerr)
     } else {
         r_out = stdout;
     }
+    setbuf(r_out, 0);
 
     return 0;
 }
@@ -132,7 +133,8 @@ void royparse_stop()
         pcap_close(pd);
         pcap_dump_close(q_out);
     }
-    fclose(r_out);
+    if (r_out != stdout)
+        fclose(r_out);
 }
 
 int royparse_open(my_bpftimeval ts)


### PR DESCRIPTION
When:
- the royparse plugin is used with another plugin, and
- that other plugin links with ldns (rzkeychange, rssm), and
- royparse writes to a file (including stdout redirect to file)

Then royparse can see duplicate data at the end of its output file.
It's as though the remaining unbuffered output gets flushed twice
or more.

A workaround is for royparse to set its output to be unbuffered.

Also royparse shouldn't close stdout.