### PR TITLE
Clean up use of feature test macros on Linux

### DIFF
--- a/src/dnscap.h
+++ b/src/dnscap.h
@@ -32,6 +32,10 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef __linux__
+#define _GNU_SOURCE
+#endif
+
 #include <sys/param.h>
 #include <sys/types.h>
 #include <sys/select.h>
@@ -48,9 +52,6 @@
 #endif
 
 #ifdef __linux__
-#define __FAVOR_BSD
-#define __USE_GNU
-#define _GNU_SOURCE
 #include <net/ethernet.h>
 #ifdef USE_SECCOMP
 #include <seccomp.h>


### PR DESCRIPTION
This PR cleans up the way feature test macros are used in `src/dnscap.h`:

 * `__FAVOR_BSD` was [removed from glibc in 2013][1], so do not use it,
 * `__USE_GNU` should not be defined manually - this triggers compiler warnings; defining `_GNU_SOURCE` causes `__USE_GNU` to be defined by `features.h`,
 * in order to be effective, `_GNU_SOURCE`, needs to be defined before any header files are included (see `man feature_test_macros`).

[1]: https://sourceware.org/git/?p=glibc.git;a=commit;h=7011c2622fe3e10a29dbe74f06aaebd07710127d
