### PR TITLE
Clean up use of feature test macros on Linux

### DIFF
--- a/src/dnscap.h
+++ b/src/dnscap.h
@@ -32,6 +32,10 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifdef __linux__
+#define _GNU_SOURCE
+#endif
+
 #include <sys/param.h>
 #include <sys/types.h>
 #include <sys/select.h>
@@ -49,8 +53,6 @@
 
 #ifdef __linux__
 #define __FAVOR_BSD
-#define __USE_GNU
-#define _GNU_SOURCE
 #include <net/ethernet.h>
 #ifdef USE_SECCOMP
 #include <seccomp.h>


### PR DESCRIPTION
This PR cleans up the way feature test macros are used in `src/dnscap.h`:

 * `__USE_GNU` should not be defined manually - this triggers compiler warnings; defining `_GNU_SOURCE` causes `__USE_GNU` to be defined by `features.h`,
 * in order to be effective, `_GNU_SOURCE`, needs to be defined before any header files are included (see `man feature_test_macros`).

This PR is an updated version of #169 that should also work on CentOS 7.
