### PR TITLE
Use pcap_findalldevs() instead of pcap_lookupdev()

### DIFF
--- a/src/args.c
+++ b/src/args.c
@@ -689,8 +689,8 @@ void parse_args(int argc, char* argv[])
         }
     }
     if (EMPTY(mypcaps)) {
-        pcap_if_t *pcapdev;
-        int res;
+        pcap_if_t* pcapdev = 0;
+        int        res;
         res = pcap_findalldevs(&pcapdev, errbuf);
         if (res == -1) {
             fprintf(stderr, "%s: pcap_findalldevs: %s\n",

--- a/src/args.c
+++ b/src/args.c
@@ -689,18 +689,24 @@ void parse_args(int argc, char* argv[])
         }
     }
     if (EMPTY(mypcaps)) {
-        const char* name;
-        name = pcap_lookupdev(errbuf);
-        if (name == NULL) {
-            fprintf(stderr, "%s: pcap_lookupdev: %s\n",
+        pcap_if_t *pcapdev;
+        int res;
+        res = pcap_findalldevs(&pcapdev, errbuf);
+        if (res == -1) {
+            fprintf(stderr, "%s: pcap_findalldevs: %s\n",
                 ProgramName, errbuf);
+            exit(1);
+        } else if (pcapdev == NULL) {
+            fprintf(stderr, "%s: pcap_findalldevs: no devices found\n",
+                ProgramName);
             exit(1);
         }
         mypcap = calloc(1, sizeof *mypcap);
         assert(mypcap != NULL);
         INIT_LINK(mypcap, link);
-        mypcap->name = (name == NULL) ? NULL : strdup(name);
+        mypcap->name = strdup(pcapdev->name);
         APPEND(mypcaps, mypcap, link);
+        pcap_freealldevs(pcapdev);
     }
     if (start_time && stop_time && start_time >= stop_time)
         usage("start time must be before stop time");


### PR DESCRIPTION
`pcap_lookupdev()` is [deprecated][1] as of libpcap 1.9.0.  The [recommended replacement][2] is to use the first device returned by `pcap_findalldevs()`.  This is what this PR implements.

[1]: https://github.com/the-tcpdump-group/libpcap/commit/7318c9438ce3ac629b2da529d4153fc6aeeb17d4
[2]: https://github.com/the-tcpdump-group/libpcap/blob/libpcap-1.9.0/pcap/pcap.h#L327