### PR TITLE
Free pointers to allocated strings in text_free()

### DIFF
--- a/src/bpft.c
+++ b/src/bpft.c
@@ -218,6 +218,7 @@ void text_free(text_list* list)
 
     while ((text = HEAD(*list)) != NULL) {
         UNLINK(*list, text, link);
+        free(text->text);
         free(text);
     }
 }


### PR DESCRIPTION
`text_free()` iterates over the provided `text_list`, removing member structures from the list and freeing them but it does not free the pointers to strings allocated by the [`vasprintf()` call inside `text_add()`][1] (these pointers are stored in the `text` field of `struct text`).  This PR adds the missing `free()` call to `text_free()`.

[1]: https://github.com/DNS-OARC/dnscap/blob/df1338c47734e22803143d9af83a029ec26513a0/src/bpft.c#L208