### PR TITLE
Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dnscap
 
-[![Build Status](https://travis-ci.org/DNS-OARC/dnscap.svg?branch=develop)](https://travis-ci.org/DNS-OARC/dnscap) [![Coverity Scan Build Status](https://scan.coverity.com/projects/10009/badge.svg)](https://scan.coverity.com/projects/dns-oarc-dnscap)
+[![Build Status](https://travis-ci.org/DNS-OARC/dnscap.svg?branch=develop)](https://travis-ci.org/DNS-OARC/dnscap) [![Coverity Scan Build Status](https://scan.coverity.com/projects/10009/badge.svg)](https://scan.coverity.com/projects/dns-oarc-dnscap) [![Total alerts](https://img.shields.io/lgtm/alerts/g/DNS-OARC/dnscap.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/DNS-OARC/dnscap/alerts/)
 
 `dnscap` is a network capture utility designed specifically for DNS traffic.
 It produces binary data in `pcap(3)` and other format. This utility is similar

--- a/contrib/cdsdump.py
+++ b/contrib/cdsdump.py
@@ -58,9 +58,8 @@ def decode_simple_value(self, fp, shareable_index=None):
 
 try:
     from cbor2.types import CBORSimpleValue
-except:
+except Exception:
     CBORSimpleValue = SimpleValue
-    pass
 
 class LastValues(object):
     def __init__(self):
@@ -466,39 +465,39 @@ def parse_ip_header(ip_header, lvl):
         elif ports < 0:
             if reverse:
                 src_port = last.dest_port6 if bits & 1 else last.dest_port4
-                if src_port == None:
+                if src_port is None:
                         raise Exception("invalid ip_header.bits, expected to have last dest port but don't")
             else:
                 src_port = last.src_port6 if bits & 1 else last.src_port4
-                if src_port == None:
+                if src_port is None:
                     raise Exception("invalid ip_header.bits, expected to have last src port but don't")
             dest_port = -ports - 1
         else:
             src_port = ports
             if reverse:
                 dest_port = last.src_port6 if bits & 1 else last.src_port4
-                if dest_port == None:
+                if dest_port is None:
                         raise Exception("invalid ip_header.bits, expected to have last src port but don't")
             else:
                 dest_port = last.dest_port6 if bits & 1 else last.dest_port4
-                if dest_port == None:
+                if dest_port is None:
                         raise Exception("invalid ip_header.bits, expected to have last dest port but don't")
     else:
         if reverse:
             src_port = last.dest_port6 if bits & 1 else last.dest_port4
-            if src_port == None:
+            if src_port is None:
                     raise Exception("invalid ip_header.bits, expected to have last dest port but don't")
         else:
             src_port = last.src_port6 if bits & 1 else last.src_port4
-            if src_port == None:
+            if src_port is None:
                 raise Exception("invalid ip_header.bits, expected to have last src port but don't")
         if reverse:
             dest_port = last.src_port6 if bits & 1 else last.src_port4
-            if dest_port == None:
+            if dest_port is None:
                     raise Exception("invalid ip_header.bits, expected to have last src port but don't")
         else:
             dest_port = last.dest_port6 if bits & 1 else last.dest_port4
-            if dest_port == None:
+            if dest_port is None:
                     raise Exception("invalid ip_header.bits, expected to have last dest port but don't")
 
     print((" " * lvl)+" src addr: " + socket.inet_ntop(socket.AF_INET6 if bits & 1 else socket.AF_INET, src_addr))
@@ -688,7 +687,7 @@ def main():
                 except Exception as e:
                     if e.__str__().find("index out of range") == -1:
                         raise
-                if obj == None:
+                if obj is None:
                     break
                 if not isinstance(obj, list):
                     raise Exception("Invalid element, expected an array but found: {}".format(type(obj)))

--- a/contrib/cdsidxchk.py
+++ b/contrib/cdsidxchk.py
@@ -36,7 +36,6 @@ import sys
 import logging
 import optparse
 import struct
-import socket
 from cbor2 import CBORDecoder;
 
 logging.basicConfig(format='%(levelname).5s: %(module)s:%(lineno)d: '
@@ -58,9 +57,8 @@ def decode_simple_value(self, fp, shareable_index=None):
 
 try:
     from cbor2.types import CBORSimpleValue
-except:
+except Exception:
     CBORSimpleValue = SimpleValue
-    pass
 
 class LastValues(object):
     def __init__(self):
@@ -289,7 +287,6 @@ def parse_rrs(rrs, lvl):
             add_rdata(rr[0])
             rr.pop(0)
             #print((" " * lvl)+"rdata: "+"".join("{:02x}".format(byte) for byte in rr.pop(0)))
-            pass
         elif isinstance(rr[0], list):
             add_rdata(rr[0])
             rdata = []
@@ -370,9 +367,9 @@ def parse_dns_message(dns, lvl):
 
     #print((" " * lvl)+"header:")
     lvl+=2
-    id = dns.pop(0)
+    id = dns.pop(0) # lgtm [py/unused-local-variable]
     #print((" " * lvl)+"id: {}".format(id))
-    raw = dns.pop(0)
+    raw = dns.pop(0) # lgtm [py/unused-local-variable]
     #print((" " * lvl)+"raw: 0x{:04x}".format(raw))
     lvl+=2
     #print((" " * lvl)+"    QR: "+("yes" if raw & 1<<15 else "no"))
@@ -466,7 +463,6 @@ def parse_dns_message(dns, lvl):
         if isinstance(dns[0], bytes):
             dns.pop(0)
             #print((" " * lvl)+"malformed: "+"".join("{:02x}".format(byte) for byte in dns.pop(0)))
-            pass
         if len(dns):
             raise Exception("invalid dns.message, garbage at end: {}".format(dns))
 
@@ -534,39 +530,39 @@ def parse_ip_header(ip_header, lvl):
         elif ports < 0:
             if reverse:
                 src_port = last.dest_port6 if bits & 1 else last.dest_port4
-                if src_port == None:
+                if src_port is None:
                         raise Exception("invalid ip_header.bits, expected to have last dest port but don't")
             else:
                 src_port = last.src_port6 if bits & 1 else last.src_port4
-                if src_port == None:
+                if src_port is None:
                     raise Exception("invalid ip_header.bits, expected to have last src port but don't")
             dest_port = -ports - 1
         else:
             src_port = ports
             if reverse:
                 dest_port = last.src_port6 if bits & 1 else last.src_port4
-                if dest_port == None:
+                if dest_port is None:
                         raise Exception("invalid ip_header.bits, expected to have last src port but don't")
             else:
                 dest_port = last.dest_port6 if bits & 1 else last.dest_port4
-                if dest_port == None:
+                if dest_port is None:
                         raise Exception("invalid ip_header.bits, expected to have last dest port but don't")
     else:
         if reverse:
             src_port = last.dest_port6 if bits & 1 else last.dest_port4
-            if src_port == None:
+            if src_port is None:
                     raise Exception("invalid ip_header.bits, expected to have last dest port but don't")
         else:
             src_port = last.src_port6 if bits & 1 else last.src_port4
-            if src_port == None:
+            if src_port is None:
                 raise Exception("invalid ip_header.bits, expected to have last src port but don't")
         if reverse:
             dest_port = last.src_port6 if bits & 1 else last.src_port4
-            if dest_port == None:
+            if dest_port is None:
                     raise Exception("invalid ip_header.bits, expected to have last src port but don't")
         else:
             dest_port = last.dest_port6 if bits & 1 else last.dest_port4
-            if dest_port == None:
+            if dest_port is None:
                     raise Exception("invalid ip_header.bits, expected to have last dest port but don't")
 
     #print((" " * lvl)+" src addr: " + socket.inet_ntop(socket.AF_INET6 if bits & 1 else socket.AF_INET, src_addr))
@@ -591,29 +587,30 @@ def parse_message_bits(bits, lvl):
     lvl+=2
     dns = "no"
     if isinstance(bits, int):
-        if bits & 1:
-            dns = "yes"
-        #print((" " * lvl)+"dns      (0): "+dns)
-
-        if bits & 1<<1:
-            proto = "tcp"
-        elif dns == "yes":
-            proto = "udp"
-        else:
-            proto = "icmp"
-        #print((" " * lvl)+"proto    (1): "+proto)
-
-        if bits & 1<<2:
-            frag = "yes"
-        else:
-            frag = "no"
-        #print((" " * lvl)+"frag     (2): "+frag)
-
-        if bits & 1<<3:
-            malformed = "yes"
-        else:
-            malformed = "no"
-        #print((" " * lvl)+"malformed(3): "+malformed)
+        # if bits & 1:
+        #     dns = "yes"
+        # #print((" " * lvl)+"dns      (0): "+dns)
+        #
+        # if bits & 1<<1:
+        #     proto = "tcp"
+        # elif dns == "yes":
+        #     proto = "udp"
+        # else:
+        #     proto = "icmp"
+        # #print((" " * lvl)+"proto    (1): "+proto)
+        #
+        # if bits & 1<<2:
+        #     frag = "yes"
+        # else:
+        #     frag = "no"
+        # #print((" " * lvl)+"frag     (2): "+frag)
+        #
+        # if bits & 1<<3:
+        #     malformed = "yes"
+        # else:
+        #     malformed = "no"
+        # #print((" " * lvl)+"malformed(3): "+malformed)
+        pass
 
     else:
         raise Exception("invalid message_bits, expected int but got: {}".format(type(bits)))
@@ -759,7 +756,7 @@ def main():
                 except Exception as e:
                     if e.__str__().find("index out of range") == -1:
                         raise
-                if obj == None:
+                if obj is None:
                     break
                 if not isinstance(obj, list):
                     raise Exception("Invalid element, expected an array but found: {}".format(type(obj)))

--- a/m4/dl.sh
+++ b/m4/dl.sh
@@ -1,21 +1,4 @@
 #!/bin/sh -e
-# Copyright (c) 2018, OARC, Inc.
-# All rights reserved.
-#
-# This file is part of dnsjit.
-#
-# dnsjit is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# dnsjit is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with dnsjit.  If not, see <http://www.gnu.org/licenses/>.
 
 m4_files="ax_append_flag.m4 ax_cflags_warn_all.m4 ax_require_defined.m4"
 

--- a/plugins/cryptopan/cryptopan.c
+++ b/plugins/cryptopan/cryptopan.c
@@ -364,14 +364,14 @@ int cryptopan_filter(const char* descr, iaddr* from, iaddr* to, uint8_t proto, u
             if (encrypt_v6) {
                 if (decrypt) {
                     _decrypt((uint32_t*)&from->u.a6);
-                    _decrypt(((uint32_t*)&from->u.a6) + 1);
-                    _decrypt(((uint32_t*)&from->u.a6) + 2);
-                    _decrypt(((uint32_t*)&from->u.a6) + 3);
+                    _decrypt(((uint32_t*)&from->u.a6) + 1); // lgtm [cpp/suspicious-pointer-scaling]
+                    _decrypt(((uint32_t*)&from->u.a6) + 2); // lgtm [cpp/suspicious-pointer-scaling]
+                    _decrypt(((uint32_t*)&from->u.a6) + 3); // lgtm [cpp/suspicious-pointer-scaling]
                 } else {
                     _encrypt((uint32_t*)&from->u.a6);
-                    _encrypt(((uint32_t*)&from->u.a6) + 1);
-                    _encrypt(((uint32_t*)&from->u.a6) + 2);
-                    _encrypt(((uint32_t*)&from->u.a6) + 3);
+                    _encrypt(((uint32_t*)&from->u.a6) + 1); // lgtm [cpp/suspicious-pointer-scaling]
+                    _encrypt(((uint32_t*)&from->u.a6) + 2); // lgtm [cpp/suspicious-pointer-scaling]
+                    _encrypt(((uint32_t*)&from->u.a6) + 3); // lgtm [cpp/suspicious-pointer-scaling]
                 }
                 break;
             }
@@ -400,14 +400,14 @@ int cryptopan_filter(const char* descr, iaddr* from, iaddr* to, uint8_t proto, u
             if (encrypt_v6) {
                 if (decrypt) {
                     _decrypt((uint32_t*)&to->u.a6);
-                    _decrypt(((uint32_t*)&to->u.a6) + 1);
-                    _decrypt(((uint32_t*)&to->u.a6) + 2);
-                    _decrypt(((uint32_t*)&to->u.a6) + 3);
+                    _decrypt(((uint32_t*)&to->u.a6) + 1); // lgtm [cpp/suspicious-pointer-scaling]
+                    _decrypt(((uint32_t*)&to->u.a6) + 2); // lgtm [cpp/suspicious-pointer-scaling]
+                    _decrypt(((uint32_t*)&to->u.a6) + 3); // lgtm [cpp/suspicious-pointer-scaling]
                 } else {
                     _encrypt((uint32_t*)&to->u.a6);
-                    _encrypt(((uint32_t*)&to->u.a6) + 1);
-                    _encrypt(((uint32_t*)&to->u.a6) + 2);
-                    _encrypt(((uint32_t*)&to->u.a6) + 3);
+                    _encrypt(((uint32_t*)&to->u.a6) + 1); // lgtm [cpp/suspicious-pointer-scaling]
+                    _encrypt(((uint32_t*)&to->u.a6) + 2); // lgtm [cpp/suspicious-pointer-scaling]
+                    _encrypt(((uint32_t*)&to->u.a6) + 3); // lgtm [cpp/suspicious-pointer-scaling]
                 }
                 break;
             }

--- a/plugins/pcapdump/pcapdump.c
+++ b/plugins/pcapdump/pcapdump.c
@@ -168,12 +168,14 @@ int pcapdump_open(my_bpftimeval ts)
     if (to_stdout) {
         t = "-";
     } else {
-        char sbuf[64];
+        char      sbuf[64];
+        struct tm tm;
         while (ts.tv_usec >= MILLION) {
             ts.tv_sec++;
             ts.tv_usec -= MILLION;
         }
-        strftime(sbuf, 64, "%Y%m%d.%H%M%S", gmtime((time_t*)&ts.tv_sec));
+        gmtime_r((time_t*)&ts.tv_sec, &tm);
+        strftime(sbuf, 64, "%Y%m%d.%H%M%S", &tm);
         if (asprintf(&dumpname, "%s.%s.%06lu",
                 dump_base, sbuf, (u_long)ts.tv_usec)
                 < 0

--- a/plugins/royparse/royparse.c
+++ b/plugins/royparse/royparse.c
@@ -53,7 +53,7 @@ static logerr_t* logerr;
 static char*     opt_q = 0;
 static char*     opt_r = 0;
 
-pcap_t*        pd;
+pcap_t*        pcap;
 pcap_dumper_t* q_out = 0;
 static FILE*   r_out = 0;
 
@@ -111,8 +111,8 @@ int royparse_start(logerr_t* a_logerr)
     logerr = a_logerr;
 
     if (opt_q) {
-        pd    = pcap_open_dead(DLT_RAW, 65535);
-        q_out = pcap_dump_open(pd, opt_q);
+        pcap  = pcap_open_dead(DLT_RAW, 65535);
+        q_out = pcap_dump_open(pcap, opt_q);
         if (q_out == 0) {
             logerr("%s: %s\n", opt_q, strerror(errno));
             exit(1);
@@ -135,7 +135,7 @@ int royparse_start(logerr_t* a_logerr)
 void royparse_stop()
 {
     if (q_out != 0) {
-        pcap_close(pd);
+        pcap_close(pcap);
         pcap_dump_close(q_out);
     }
     if (r_out != stdout)

--- a/src/bpft.c
+++ b/src/bpft.c
@@ -214,11 +214,15 @@ size_t text_add(text_list* list, const char* fmt, ...)
 
 void text_free(text_list* list)
 {
-    text_ptr text;
+    text_ptr at, text;
 
-    while ((text = HEAD(*list)) != NULL) {
+    for (at = HEAD(*list); at;) {
+        text = at;
+        at   = NEXT(text, link);
+
         UNLINK(*list, text, link);
         free(text->text);
+        assert(text != (void*)-1);
         free(text);
     }
 }

--- a/src/dnscap.c
+++ b/src/dnscap.c
@@ -138,9 +138,10 @@ int main(int argc, char* argv[])
     gettimeofday(&now, 0);
     if (!only_offline_pcaps && start_time) {
         if (now.tv_sec < start_time) {
-            char       when[100];
-            struct tm* tm = gmtime(&start_time);
-            strftime(when, sizeof when, "%F %T", tm);
+            char      when[100];
+            struct tm tm;
+            gmtime_r(&start_time, &tm);
+            strftime(when, sizeof when, "%F %T", &tm);
             fprintf(stderr, "Sleeping for %d seconds until %s UTC\n",
                 (int)(start_time - now.tv_sec), when);
             sleep(start_time - now.tv_sec);

--- a/src/dnscap.h
+++ b/src/dnscap.h
@@ -32,6 +32,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifndef __dnscap_dnscap_h
+#define __dnscap_dnscap_h
+
 #ifdef __linux__
 #define _GNU_SOURCE
 #endif
@@ -211,9 +214,6 @@
 #include "dump_cds.h"
 #include "options.h"
 #include "pcap-thread/pcap_thread.h"
-
-#ifndef __dnscap_dnscap_h
-#define __dnscap_dnscap_h
 
 struct text {
     LINK(struct text)

--- a/src/dnscap_common.h
+++ b/src/dnscap_common.h
@@ -32,6 +32,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifndef __dnscap_dnscap_common_h
+#define __dnscap_dnscap_common_h
+
 #include <netinet/in.h>
 #include <sys/types.h>
 
@@ -45,9 +48,6 @@
 #include <time.h>
 #endif
 #endif
-
-#ifndef __dnscap_dnscap_common_h
-#define __dnscap_dnscap_common_h
 
 /*
  * setup MY_BPFTIMEVAL as the timeval structure that bpf packets

--- a/src/dumper.c
+++ b/src/dumper.c
@@ -160,9 +160,11 @@ int dumper_open(my_bpftimeval ts)
     if (dump_type == to_stdout) {
         t = "-";
     } else if (dump_type == to_file) {
-        char sbuf[64];
+        char      sbuf[64];
+        struct tm tm;
 
-        strftime(sbuf, 64, "%Y%m%d.%H%M%S", gmtime((time_t*)&ts.tv_sec));
+        gmtime_r((time_t*)&ts.tv_sec, &tm);
+        strftime(sbuf, 64, "%Y%m%d.%H%M%S", &tm);
         if (asprintf(&dumpname, "%s.%s.%06lu%s",
                 dump_base, sbuf,
                 (u_long)ts.tv_usec, dump_suffix ? dump_suffix : "")

--- a/src/tcpreasm.c
+++ b/src/tcpreasm.c
@@ -235,7 +235,6 @@ static int dns_protocol_handler(tcpreasm_t* t, u_char* segment, uint16_t dnslen,
                     break;
                 }
             }
-            len = t->bfb_at;
         }
         return 0;
     }


### PR DESCRIPTION
- Fix clang `scan-build` bugs and LGTM alerts
- Add LGTM badge
- Use `gmtime_r()` instead of `gmtime()`
- Update `pcap-thread` to v4.0.0
- `rssm`: Use `memset()` to zero out last 8 bytes in IPv6 address
- `text_free()`: Rewrite and add `assert()` to silence `scan-build` false-positive