### PR TITLE
README, compile warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ To install some of the dependencies under OpenBSD 5+ using `pkg_add`:
 pkg_add libldns p5-YAML
 ```
 
+NOTE: It is recommended to install the PCAP library from source/ports on
+OpenBSD since the bundled version is an older and modified version.
+
 ### Dependencies for `cryptopant.so` plugin
 
 For this plugin a library call `cryptopANT` is required and the original
@@ -85,8 +88,8 @@ make install
 
 If you are building `dnscap` from it's Git repository you will first need
 to initiate the Git submodules that exists and later create autoconf/automake
-files, this will require a build environment with Autoconf, Automake and
-Libtool to be installed.
+files, this will require a build environment with autoconf, automake, libtool
+and pkg-config to be installed.
 
 ```
 git clone https://github.com/DNS-OARC/dnscap.git

--- a/plugins/cryptopan/cryptopan.c
+++ b/plugins/cryptopan/cryptopan.c
@@ -279,20 +279,33 @@ int cryptopan_close(my_bpftimeval ts)
 }
 
 #ifdef USE_OPENSSL
+struct input {
+    union {
+        unsigned char input[16];
+        uint32_t      ui32;
+    } u;
+};
+struct output {
+    union {
+        unsigned char outbuf[16 + EVP_MAX_BLOCK_LENGTH];
+        uint32_t      ui32;
+    } u;
+};
 static inline void _encrypt(uint32_t* in)
 {
-    unsigned char input[16], outbuf[16 + EVP_MAX_BLOCK_LENGTH];
+    struct input  input;
+    struct output output;
     int           outlen = 0, pos;
     uint32_t      orig, result = 0, pad4b, mask = 0;
 
-    memcpy(input, pad, 16);
-    orig  = ntohl(*in);
-    pad4b = *(uint32_t*)pad;
+    memcpy(input.u.input, pad, 16);
+    orig = ntohl(*in);
+    memcpy(&pad4b, pad, 4);
 
     for (pos = 0; pos < 32; pos++) {
-        *(uint32_t*)input = htonl(((pad4b << pos) | (pad4b >> (32 - pos))) ^ (orig & mask));
+        input.u.ui32 = htonl(((pad4b << pos) | (pad4b >> (32 - pos))) ^ (orig & mask));
 
-        if (!EVP_CipherUpdate(ctx, outbuf, &outlen, input, 16)) {
+        if (!EVP_CipherUpdate(ctx, output.u.outbuf, &outlen, input.u.input, 16)) {
             fprintf(stderr, "cryptopan.so: error encrypting: %s\n", ERR_reason_error_string(ERR_get_error()));
             exit(1);
         }
@@ -301,7 +314,7 @@ static inline void _encrypt(uint32_t* in)
             exit(1);
         }
 
-        result |= ((ntohl(*(u_int32_t*)outbuf)) & 0x80000000) >> pos;
+        result |= ((ntohl(output.u.ui32)) & 0x80000000) >> pos;
         mask >>= 1;
         mask |= 0x80000000;
     }
@@ -311,18 +324,19 @@ static inline void _encrypt(uint32_t* in)
 
 static inline void _decrypt(uint32_t* in)
 {
-    unsigned char input[16], outbuf[16 + EVP_MAX_BLOCK_LENGTH];
+    struct input  input;
+    struct output output;
     int           outlen = 0, pos;
     uint32_t      orig, pad4b, mask = 0;
 
-    memcpy(input, pad, 16);
-    orig  = ntohl(*in);
-    pad4b = *(uint32_t*)pad;
+    memcpy(input.u.input, pad, 16);
+    orig = ntohl(*in);
+    memcpy(&pad4b, pad, 4);
 
     for (pos = 0; pos < 32; pos++) {
-        *(uint32_t*)input = htonl(((pad4b << pos) | (pad4b >> (32 - pos))) ^ (orig & mask));
+        input.u.ui32 = htonl(((pad4b << pos) | (pad4b >> (32 - pos))) ^ (orig & mask));
 
-        if (!EVP_CipherUpdate(ctx, outbuf, &outlen, input, 16)) {
+        if (!EVP_CipherUpdate(ctx, output.u.outbuf, &outlen, input.u.input, 16)) {
             fprintf(stderr, "cryptopan.so: error encrypting: %s\n", ERR_reason_error_string(ERR_get_error()));
             exit(1);
         }
@@ -331,7 +345,7 @@ static inline void _decrypt(uint32_t* in)
             exit(1);
         }
 
-        orig ^= ((ntohl(*(u_int32_t*)outbuf)) & 0x80000000) >> pos;
+        orig ^= ((ntohl(output.u.ui32)) & 0x80000000) >> pos;
         mask >>= 1;
         mask |= 0x80000000;
     }

--- a/src/dump_dns.c
+++ b/src/dump_dns.c
@@ -230,7 +230,7 @@ dump_dns_rr(ns_msg* msg, ns_rr* rr, ns_sect sect, FILE* trace)
             goto error;
         for (n = 0; n < 5; n++)
             MY_GET32(soa[n], rd);
-        sprintf(buf, "%u,%u,%u,%u,%u",
+        snprintf(buf, sizeof(buf), "%u,%u,%u,%u,%u",
             soa[0], soa[1], soa[2], soa[3], soa[4]);
         break;
     case ns_t_a:
@@ -331,15 +331,15 @@ dump_dns_rr(ns_msg* msg, ns_rr* rr, ns_sect sect, FILE* trace)
                 memset(addr, 0, sizeof addr);
                 memcpy(addr, rd, edns0lenopt < sizeof(addr) ? edns0lenopt : sizeof(addr));
 
+                buf[0] = 0;
                 if (afi == 0x1) {
                     inet_ntop(AF_INET, addr, buf, sizeof buf);
                 } else if (afi == 0x2) {
                     inet_ntop(AF_INET6, addr, buf, sizeof buf);
                 } else {
                     fprintf(trace, "unknown AFI %d\n", afi);
-                    strcpy(buf, "<unknown>");
                 }
-                fprintf(trace, "edns0_client_subnet=%s/%d (scope %d)", buf, srcmask, scomask);
+                fprintf(trace, "edns0_client_subnet=%s/%d (scope %d)", buf[0] ? buf : "<unknown>", srcmask, scomask);
             }
             /* increment the rd pointer by the remaining option data size */
             rd += edns0lenopt;
@@ -348,7 +348,7 @@ dump_dns_rr(ns_msg* msg, ns_rr* rr, ns_sect sect, FILE* trace)
 
     default:
     error:
-        sprintf(buf, "[%u]", ns_rr_rdlen(*rr));
+        snprintf(buf, sizeof(buf), "[%u]", ns_rr_rdlen(*rr));
     }
     if (buf[0] != '\0') {
         putc(',', trace);

--- a/src/network.c
+++ b/src/network.c
@@ -387,19 +387,24 @@ void dl_pkt(u_char* user, const struct pcap_pkthdr* hdr, const u_char* pkt, cons
     }
 
     if (preso) {
-        char      when[100], via[100];
-        struct tm tm;
-        time_t    t;
+        char        when[100], via[100];
+        const char* viap;
+        struct tm   tm;
+        time_t      t;
 
         t = (time_t)hdr->ts.tv_sec;
         gmtime_r(&t, &tm);
         strftime(when, sizeof when, "%Y-%m-%d %T", &tm);
-        strcpy(via, (mypcap->name == NULL) ? "\"some interface\"" : mypcap->name);
-        if (vlan != MAX_VLAN)
-            sprintf(via + strlen(via), " (vlan %u)", vlan);
-        sprintf(descr, "[%lu] %s.%06lu [#%ld %s %u] \\\n",
-            (u_long)len, when, (u_long)hdr->ts.tv_usec,
-            (long)msgcount, via, vlan);
+        if (vlan != MAX_VLAN) {
+            snprintf(via, sizeof(via), "%s (vlan %u)", mypcap->name ? mypcap->name : "\"some interface\"", vlan);
+            viap = via;
+        } else if (mypcap->name) {
+            viap = mypcap->name;
+        } else {
+            viap = "\"some interface\"";
+        }
+        snprintf(descr, sizeof(descr), "[%lu] %s.%06lu [#%ld %s %u] \\\n",
+            (u_long)len, when, (u_long)hdr->ts.tv_usec, (long)msgcount, viap, vlan);
     } else {
         descr[0] = '\0';
     }


### PR DESCRIPTION
- Update `README.md` with correction to building from git and note about PCAP on OpenBSD
- `dump_dns`: Remove usage of `strcpy()` and use `snprintf()` instead of `sprintf()`
- `bpft`:
  - Use `text_ptr->len` to store length of generated text
  - Use `memcpy()` instead of `strcat()`
  - Remove unneeded `realloc()` and `strcpy()`
- `plugins/cryptopan`: Fix strict-aliasing warnings
- `network`: Rework part of `dl_pkt()` to remove usage of `strcpy()` and use `snprintf()` instead of `sprintf()`