### PR TITLE
libbind

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,19 +32,16 @@ General support and discussion:
 `dnscap` requires a couple of libraries beside a normal C compiling
 environment with autoconf, automake, libtool and pkgconfig.
 
-`dnscap` has a non-optional dependency on the PCAP library and optional
-dependencies on LDNS. BIND library `libbind` is considered optional but it
-is needed under OpenBSD for various `arpa/nameser*` include headers, see
-[Linking with libbind](#linking-with-libbind).
+`dnscap` has a non-optional dependency on the PCAP library and LDNS.
 
 To install the dependencies under Debian/Ubuntu:
 ```
-apt-get install -y libpcap-dev libldns-dev libbind-dev zlib1g-dev libyaml-perl libssl-dev
+apt-get install -y libpcap-dev libldns-dev zlib1g-dev libyaml-perl libssl-dev
 ```
 
 To install the dependencies under CentOS (with EPEL enabled):
 ```
-yum install -y libpcap-devel ldns-devel openssl-devel bind-devel zlib-devel perl-YAML
+yum install -y libpcap-devel ldns-devel openssl-devel zlib-devel perl-YAML
 ```
 
 For the following OS you will need to install some of the dependencies
@@ -103,21 +100,6 @@ make
 make install
 ```
 
-## Linking with libbind
-
-If you plan to use dnscap's -x/-X features, then you might need
-to have libbind installed.   These features use functions such
-as ns_parserr().  On some systems these functions will be found
-in libresolv.  If not, then you might need to install libbind.
-I suggest first building dnscap on your system as-is, then run
-
-```
-$ ./dnscap -x foo
-```
-
-If you see an error, install libbind either from your OS package system
-or by downloading the source from http://ftp.isc.org/isc/libbind/6.0/ .
-
 ### 64-bit libraries
 
 If you need to link against 64-bit libraries found in non-standard
@@ -130,40 +112,12 @@ $ env LDFLAGS=-L/usr/lib64 ./configure
 
 ### OpenBSD
 
-For OpenBSD you probably installed libpcap and libbind in `/usr/local`
-so you will need to tell `configure` that and libbind might install it's
-libraries and header files in a subdirectory:
+For OpenBSD you probably installed libpcap in `/usr/local` so you will need
+to tell `configure` where to find the libraries and header files:
 
 ```
-$ env CFLAGS="-I/usr/local/include -I/usr/local/include/bind" \
-  LDFLAGS="-L/usr/local/lib -L/usr/local/lib/bind" \
-  ./configure
+$ env CFLAGS="-I/usr/local/include" LDFLAGS="-L/usr/local/lib" ./configure
 ```
-
-*KNOWN ISSUES*:
-- libbind export the symbol `_res` which also exists in OpenBSD's libc, this causes it to throw warnings like `dnscap:/usr/lib/libc.so.96.0: /usr/local/lib/libbind.so.6.1 : WARNING: symbol(_res) size mismatch, relink your program` and may segfault.
-- due to above, known to segfault in libpcap when using IPv6 addresses in BPF, see https://github.com/the-tcpdump-group/libpcap/issues/964
-- this will be addressed in future versions of `dnscap`, see https://github.com/DNS-OARC/dnscap/issues/11
-
-### FreeBSD
-
-If you've installed libbind for -x/-X then it probably went into
-/usr/local and you'll need to tell configure how to find it:
-
-```
-$ env CFLAGS="-I/usr/local/include -I/usr/local/include/bind" \
-  LDFLAGS="-L/usr/local/lib -L/usr/local/lib/bind" \
-  ./configure
-```
-
-Also note that we have observed significant memory leaks on FreeBSD
-(7.2) when using -x/-X.  To rectify:
-
-1. cd /usr/ports/dns/libbind
-1. make config
-1. de-select "Compile with thread support"
-1. reinstall the libbind port
-1. recompile and install dnscap
 
 ## Plugins
 

--- a/configure.ac
+++ b/configure.ac
@@ -78,22 +78,17 @@ AM_CONDITIONAL([ENABLE_GCOV], [test "x$enable_gcov" != "xno"])
 AM_EXTRA_RECURSIVE_TARGETS([gcov])
 
 # Checks for libraries.
-AC_CHECK_LIB([bind], [ns_initparse], [], [AC_CHECK_LIB([bind], [__ns_initparse])])
-AC_CHECK_LIB([resolv], [res_mkquery], [], [
-	AC_CHECK_LIB([resolv], [__res_mkquery], [], [
-		AC_CHECK_LIB([resolv], [res_9_mkquery])
-	])
-])
 AC_CHECK_LIB([dl], [dlopen])
 AC_CHECK_LIB([tinycbor], [cbor_parser_init])
 AM_CONDITIONAL([HAVE_CBOR], [test "x$ac_cv_lib_tinycbor_cbor_parser_init" = "xyes"])
-AC_CHECK_LIB([ldns], [ldns_wire2pkt])
-AM_CONDITIONAL([HAVE_LDNS], [test "x$ac_cv_lib_ldns_ldns_wire2pkt" = "xyes"])
 AC_CHECK_LIB([z], [gzopen])
 PKG_CHECK_MODULES([libcrypto], [libcrypto],
     [AC_DEFINE([HAVE_LIBCRYPTO], [1], [Define to 1 if you have libcrypto.])])
 AC_CHECK_LIB([cryptopant], [scramble_init], [], [
     AC_CHECK_LIB([cryptopANT], [scramble_init])
+])
+PKG_CHECK_MODULES([libldns], [libldns], , [
+  PKG_CHECK_MODULES([libldns], [ldns])
 ])
 
 # Check for OS specific libraries
@@ -122,41 +117,12 @@ AC_CHECK_HEADERS([sys/time.h])
 AC_CHECK_HEADERS([zlib.h])
 AC_CHECK_HEADERS([openssl/conf.h openssl/evp.h openssl/err.h])
 AC_CHECK_HEADERS([cryptopANT.h])
+AC_CHECK_HEADERS([endian.h sys/endian.h machine/endian.h])
 
 # Checks for library functions.
 AC_CHECK_FUNCS([snprintf])
 AC_CHECK_FUNCS([setreuid setresuid setregid setresgid setegid seteuid initgroups setgroups])
 AC_CHECK_FUNCS([funopen fopencookie gzopen])
-AC_CHECK_FUNC([ns_initparse],
-    [AC_DEFINE([HAVE_NS_INITPARSE], [1], [Define to 1 if you have the `ns_initparse' function.])],
-    [AC_CHECK_FUNC(__ns_initparse,
-        [AC_DEFINE([HAVE_NS_INITPARSE], [1], [Define to 1 if you have the `ns_initparse' function.])]
-    )]
-)
-AC_CHECK_FUNC([ns_parserr],
-    [AC_DEFINE([HAVE_NS_PARSERR], [1], [Define to 1 if you have the `ns_parserr' function.])],
-    [AC_CHECK_FUNC(__ns_parserr,
-        [AC_DEFINE([HAVE_NS_PARSERR], [1], [Define to 1 if you have the `ns_parserr' function.])]
-    )]
-)
-AC_CHECK_FUNC([ns_sprintrr],
-    [AC_DEFINE([HAVE_NS_SPRINTRR], [1], [Define to 1 if you have the `ns_sprintrr' function.])],
-    [AC_CHECK_FUNC(__ns_sprintrr,
-        [AC_DEFINE([HAVE_NS_SPRINTRR], [1], [Define to 1 if you have the `ns_sprintrr' function.])]
-    )]
-)
-AC_CHECK_FUNC([ns_name_uncompress],
-    [AC_DEFINE([HAVE_NS_NAME_UNCOMPRESS], [1], [Define to 1 if you have the `ns_name_uncompress' function.])],
-    [AC_CHECK_FUNC(__ns_name_uncompress,
-        [AC_DEFINE([HAVE_NS_NAME_UNCOMPRESS], [1], [Define to 1 if you have the `ns_name_uncompress' function.])]
-    )]
-)
-AC_CHECK_FUNC([p_rcode],
-    [AC_DEFINE([HAVE_P_RCODE], [1], [Define to 1 if you have the `p_rcode' function.])],
-    [AC_CHECK_FUNC(__p_rcode,
-        [AC_DEFINE([HAVE_P_RCODE], [1], [Define to 1 if you have the `p_rcode' function.])]
-    )]
-)
 AC_CHECK_FUNCS([__assertion_failed])
 
 # Check for SECCOMP

--- a/plugins/anonaes128/test2.gold
+++ b/plugins/anonaes128/test2.gold
@@ -2,38 +2,32 @@
 	[4a92:a508:d567:5c16:d07:5236:4b51:417e].51972 [6733:3377:d5f:662b:299f:6a97:c7fe:d424].53  \
 	dns QUERY,NOERROR,51420,rd|ad \
 	1 google.com,IN,A 0 0 \
-	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0]
 [103] 2018-11-27 15:52:00.428453 [#1 dns6.pcap-dist 4095] \
 	[6733:3377:d5f:662b:299f:6a97:c7fe:d424].53 [4a92:a508:d567:5c16:d07:5236:4b51:417e].51972  \
 	dns QUERY,NOERROR,51420,qr|rd|ra \
 	1 google.com,IN,A \
 	1 google.com,IN,A,299,172.217.20.46 0 \
-	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0]
 [87] 2018-11-27 15:52:00.414188 [#0 dns6.pcap-dist 4095] \
 	[4a92:a508:d567:5c16:d07:5236:4b51:417e].51972 [2001:4860:4860::8888].53  \
 	dns QUERY,NOERROR,51420,rd|ad \
 	1 google.com,IN,A 0 0 \
-	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0]
 [103] 2018-11-27 15:52:00.428453 [#1 dns6.pcap-dist 4095] \
 	[2001:4860:4860::8888].53 [4a92:a508:d567:5c16:d07:5236:4b51:417e].51972  \
 	dns QUERY,NOERROR,51420,qr|rd|ra \
 	1 google.com,IN,A \
 	1 google.com,IN,A,299,172.217.20.46 0 \
-	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0]
 [87] 2018-11-27 15:52:00.414188 [#0 dns6.pcap-dist 4095] \
 	[2a01:3f0:0:57::245].51972 [6733:3377:d5f:662b:299f:6a97:c7fe:d424].53  \
 	dns QUERY,NOERROR,51420,rd|ad \
 	1 google.com,IN,A 0 0 \
-	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0]
 [103] 2018-11-27 15:52:00.428453 [#1 dns6.pcap-dist 4095] \
 	[6733:3377:d5f:662b:299f:6a97:c7fe:d424].53 [2a01:3f0:0:57::245].51972  \
 	dns QUERY,NOERROR,51420,qr|rd|ra \
 	1 google.com,IN,A \
 	1 google.com,IN,A,299,172.217.20.46 0 \
-	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0]

--- a/plugins/anonaes128/test3.gold
+++ b/plugins/anonaes128/test3.gold
@@ -2,12 +2,10 @@
 	[2a01:3f0:0:57::245].51972 [2001:4860:4860::8888].53  \
 	dns QUERY,NOERROR,51420,rd|ad \
 	1 google.com,IN,A 0 0 \
-	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0]
 [103] 2018-11-27 15:52:00.428453 [#1 test3.pcap.20181127.155200.414188 4095] \
 	[2001:4860:4860::8888].53 [2a01:3f0:0:57::245].51972  \
 	dns QUERY,NOERROR,51420,qr|rd|ra \
 	1 google.com,IN,A \
 	1 google.com,IN,A,299,172.217.20.46 0 \
-	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0]

--- a/plugins/anonmask/test2.gold
+++ b/plugins/anonmask/test2.gold
@@ -2,90 +2,76 @@
 	[2a01:3f0::].51972 [2001:4860:4860::].53  \
 	dns QUERY,NOERROR,51420,rd|ad \
 	1 google.com,IN,A 0 0 \
-	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0]
 [103] 2018-11-27 15:52:00.428453 [#1 dns6.pcap-dist 4095] \
 	[2001:4860:4860::].53 [2a01:3f0::].51972  \
 	dns QUERY,NOERROR,51420,qr|rd|ra \
 	1 google.com,IN,A \
 	1 google.com,IN,A,299,172.217.20.46 0 \
-	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0]
 [87] 2018-11-27 15:52:00.414188 [#0 dns6.pcap-dist 4095] \
 	[2a01:300::].51972 [2001:4800::].53  \
 	dns QUERY,NOERROR,51420,rd|ad \
 	1 google.com,IN,A 0 0 \
-	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0]
 [103] 2018-11-27 15:52:00.428453 [#1 dns6.pcap-dist 4095] \
 	[2001:4800::].53 [2a01:300::].51972  \
 	dns QUERY,NOERROR,51420,qr|rd|ra \
 	1 google.com,IN,A \
 	1 google.com,IN,A,299,172.217.20.46 0 \
-	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0]
 [87] 2018-11-27 15:52:00.414188 [#0 dns6.pcap-dist 4095] \
 	[2a01:3f0::].51972 [2001:4860::].53  \
 	dns QUERY,NOERROR,51420,rd|ad \
 	1 google.com,IN,A 0 0 \
-	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0]
 [103] 2018-11-27 15:52:00.428453 [#1 dns6.pcap-dist 4095] \
 	[2001:4860::].53 [2a01:3f0::].51972  \
 	dns QUERY,NOERROR,51420,qr|rd|ra \
 	1 google.com,IN,A \
 	1 google.com,IN,A,299,172.217.20.46 0 \
-	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0]
 [87] 2018-11-27 15:52:00.414188 [#0 dns6.pcap-dist 4095] \
 	[2a01:3f0:0:57::].51972 [2001:4860:4860::].53  \
 	dns QUERY,NOERROR,51420,rd|ad \
 	1 google.com,IN,A 0 0 \
-	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0]
 [103] 2018-11-27 15:52:00.428453 [#1 dns6.pcap-dist 4095] \
 	[2001:4860:4860::].53 [2a01:3f0:0:57::].51972  \
 	dns QUERY,NOERROR,51420,qr|rd|ra \
 	1 google.com,IN,A \
 	1 google.com,IN,A,299,172.217.20.46 0 \
-	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0]
 [87] 2018-11-27 15:52:00.414188 [#0 dns6.pcap-dist 4095] \
 	[2a01:3f0:0:57::].51972 [2001:4860:4860::].53  \
 	dns QUERY,NOERROR,51420,rd|ad \
 	1 google.com,IN,A 0 0 \
-	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0]
 [103] 2018-11-27 15:52:00.428453 [#1 dns6.pcap-dist 4095] \
 	[2001:4860:4860::].53 [2a01:3f0:0:57::].51972  \
 	dns QUERY,NOERROR,51420,qr|rd|ra \
 	1 google.com,IN,A \
 	1 google.com,IN,A,299,172.217.20.46 0 \
-	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0]
 [87] 2018-11-27 15:52:00.414188 [#0 dns6.pcap-dist 4095] \
 	[2a01:3f0::].51972 [2001:4860:4860::8888].53  \
 	dns QUERY,NOERROR,51420,rd|ad \
 	1 google.com,IN,A 0 0 \
-	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0]
 [103] 2018-11-27 15:52:00.428453 [#1 dns6.pcap-dist 4095] \
 	[2001:4860:4860::8888].53 [2a01:3f0::].51972  \
 	dns QUERY,NOERROR,51420,qr|rd|ra \
 	1 google.com,IN,A \
 	1 google.com,IN,A,299,172.217.20.46 0 \
-	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0]
 [87] 2018-11-27 15:52:00.414188 [#0 dns6.pcap-dist 4095] \
 	[2a01:3f0:0:57::245].51972 [2001:4860:4860::].53  \
 	dns QUERY,NOERROR,51420,rd|ad \
 	1 google.com,IN,A 0 0 \
-	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0]
 [103] 2018-11-27 15:52:00.428453 [#1 dns6.pcap-dist 4095] \
 	[2001:4860:4860::].53 [2a01:3f0:0:57::245].51972  \
 	dns QUERY,NOERROR,51420,qr|rd|ra \
 	1 google.com,IN,A \
 	1 google.com,IN,A,299,172.217.20.46 0 \
-	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0]

--- a/plugins/cryptopan/test2.gold
+++ b/plugins/cryptopan/test2.gold
@@ -2,38 +2,32 @@
 	[11eb:460f:2668:8b63:2668:8b2a:2668:8948].51972 [1845:9ab2:426f:b370:2668:8b2a:2668:33ab].53  \
 	dns QUERY,NOERROR,51420,rd|ad \
 	1 google.com,IN,A 0 0 \
-	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0]
 [103] 2018-11-27 15:52:00.428453 [#1 dns6.pcap-dist 4095] \
 	[1845:9ab2:426f:b370:2668:8b2a:2668:33ab].53 [11eb:460f:2668:8b63:2668:8b2a:2668:8948].51972  \
 	dns QUERY,NOERROR,51420,qr|rd|ra \
 	1 google.com,IN,A \
 	1 google.com,IN,A,299,172.217.20.46 0 \
-	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0]
 [87] 2018-11-27 15:52:00.414188 [#0 dns6.pcap-dist 4095] \
 	[11eb:460f:2668:8b63:2668:8b2a:2668:8948].51972 [2001:4860:4860::8888].53  \
 	dns QUERY,NOERROR,51420,rd|ad \
 	1 google.com,IN,A 0 0 \
-	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0]
 [103] 2018-11-27 15:52:00.428453 [#1 dns6.pcap-dist 4095] \
 	[2001:4860:4860::8888].53 [11eb:460f:2668:8b63:2668:8b2a:2668:8948].51972  \
 	dns QUERY,NOERROR,51420,qr|rd|ra \
 	1 google.com,IN,A \
 	1 google.com,IN,A,299,172.217.20.46 0 \
-	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0]
 [87] 2018-11-27 15:52:00.414188 [#0 dns6.pcap-dist 4095] \
 	[2a01:3f0:0:57::245].51972 [1845:9ab2:426f:b370:2668:8b2a:2668:33ab].53  \
 	dns QUERY,NOERROR,51420,rd|ad \
 	1 google.com,IN,A 0 0 \
-	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0]
 [103] 2018-11-27 15:52:00.428453 [#1 dns6.pcap-dist 4095] \
 	[1845:9ab2:426f:b370:2668:8b2a:2668:33ab].53 [2a01:3f0:0:57::245].51972  \
 	dns QUERY,NOERROR,51420,qr|rd|ra \
 	1 google.com,IN,A \
 	1 google.com,IN,A,299,172.217.20.46 0 \
-	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0]

--- a/plugins/cryptopan/test3.gold
+++ b/plugins/cryptopan/test3.gold
@@ -716,12 +716,10 @@
 	[2a01:3f0:0:57::245].51972 [2001:4860:4860::8888].53  \
 	dns QUERY,NOERROR,51420,rd|ad \
 	1 google.com,IN,A 0 0 \
-	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0]
 [103] 2018-11-27 15:52:00.428453 [#1 test3.pcap.20181127.155200.414188 4095] \
 	[2001:4860:4860::8888].53 [2a01:3f0:0:57::245].51972  \
 	dns QUERY,NOERROR,51420,qr|rd|ra \
 	1 google.com,IN,A \
 	1 google.com,IN,A,299,172.217.20.46 0 \
-	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0]

--- a/plugins/cryptopant/test2.gold
+++ b/plugins/cryptopant/test2.gold
@@ -2,38 +2,32 @@
 	[2a01:3a0:52c7:8483:3fd2:892c:443c:197e].51972 [2001:48e7:eb7b:8330:a6b3:e29f:c7a1:a114].53  \
 	dns QUERY,NOERROR,51420,rd|ad \
 	1 google.com,IN,A 0 0 \
-	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0]
 [103] 2018-11-27 15:52:00.428453 [#1 dns6.pcap-dist 4095] \
 	[2001:48e7:eb7b:8330:a6b3:e29f:c7a1:a114].53 [2a01:3a0:52c7:8483:3fd2:892c:443c:197e].51972  \
 	dns QUERY,NOERROR,51420,qr|rd|ra \
 	1 google.com,IN,A \
 	1 google.com,IN,A,299,172.217.20.46 0 \
-	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0]
 [87] 2018-11-27 15:52:00.414188 [#0 dns6.pcap-dist 4095] \
 	[f97c:c1a0:52c7:8483:3fd2:892c:443c:197e].51972 [2001:4860:4860::8888].53  \
 	dns QUERY,NOERROR,51420,rd|ad \
 	1 google.com,IN,A 0 0 \
-	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0]
 [103] 2018-11-27 15:52:00.428453 [#1 dns6.pcap-dist 4095] \
 	[2001:4860:4860::8888].53 [f97c:c1a0:52c7:8483:3fd2:892c:443c:197e].51972  \
 	dns QUERY,NOERROR,51420,qr|rd|ra \
 	1 google.com,IN,A \
 	1 google.com,IN,A,299,172.217.20.46 0 \
-	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0]
 [87] 2018-11-27 15:52:00.414188 [#0 dns6.pcap-dist 4095] \
 	[2a01:3f0:0:57::245].51972 [f29a:ede7:eb7b:8330:a6b3:e29f:c7a1:a114].53  \
 	dns QUERY,NOERROR,51420,rd|ad \
 	1 google.com,IN,A 0 0 \
-	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0]
 [103] 2018-11-27 15:52:00.428453 [#1 dns6.pcap-dist 4095] \
 	[f29a:ede7:eb7b:8330:a6b3:e29f:c7a1:a114].53 [2a01:3f0:0:57::245].51972  \
 	dns QUERY,NOERROR,51420,qr|rd|ra \
 	1 google.com,IN,A \
 	1 google.com,IN,A,299,172.217.20.46 0 \
-	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0]

--- a/plugins/cryptopant/test3.gold
+++ b/plugins/cryptopant/test3.gold
@@ -716,12 +716,10 @@
 	[2a01:3f0:0:57::245].51972 [2001:4860:4860::8888].53  \
 	dns QUERY,NOERROR,51420,rd|ad \
 	1 google.com,IN,A 0 0 \
-	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0]
 [103] 2018-11-27 15:52:00.428453 [#1 test3.pcap.20181127.155200.414188 4095] \
 	[2001:4860:4860::8888].53 [2a01:3f0:0:57::245].51972  \
 	dns QUERY,NOERROR,51420,qr|rd|ra \
 	1 google.com,IN,A \
 	1 google.com,IN,A,299,172.217.20.46 0 \
-	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0]

--- a/plugins/ipcrypt/test2.gold
+++ b/plugins/ipcrypt/test2.gold
@@ -2,38 +2,32 @@
 	[150a:8a55:31dc:6eac:cbc:bc41:5a09:3606].51972 [830c:987b:b17f:8b55:cbc:bc41:6b7c:2e56].53  \
 	dns QUERY,NOERROR,51420,rd|ad \
 	1 google.com,IN,A 0 0 \
-	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0]
 [103] 2018-11-27 15:52:00.428453 [#1 dns6.pcap-dist 4095] \
 	[830c:987b:b17f:8b55:cbc:bc41:6b7c:2e56].53 [150a:8a55:31dc:6eac:cbc:bc41:5a09:3606].51972  \
 	dns QUERY,NOERROR,51420,qr|rd|ra \
 	1 google.com,IN,A \
 	1 google.com,IN,A,299,172.217.20.46 0 \
-	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0]
 [87] 2018-11-27 15:52:00.414188 [#0 dns6.pcap-dist 4095] \
 	[150a:8a55:31dc:6eac:cbc:bc41:5a09:3606].51972 [2001:4860:4860::8888].53  \
 	dns QUERY,NOERROR,51420,rd|ad \
 	1 google.com,IN,A 0 0 \
-	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0]
 [103] 2018-11-27 15:52:00.428453 [#1 dns6.pcap-dist 4095] \
 	[2001:4860:4860::8888].53 [150a:8a55:31dc:6eac:cbc:bc41:5a09:3606].51972  \
 	dns QUERY,NOERROR,51420,qr|rd|ra \
 	1 google.com,IN,A \
 	1 google.com,IN,A,299,172.217.20.46 0 \
-	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0]
 [87] 2018-11-27 15:52:00.414188 [#0 dns6.pcap-dist 4095] \
 	[2a01:3f0:0:57::245].51972 [830c:987b:b17f:8b55:cbc:bc41:6b7c:2e56].53  \
 	dns QUERY,NOERROR,51420,rd|ad \
 	1 google.com,IN,A 0 0 \
-	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0]
 [103] 2018-11-27 15:52:00.428453 [#1 dns6.pcap-dist 4095] \
 	[830c:987b:b17f:8b55:cbc:bc41:6b7c:2e56].53 [2a01:3f0:0:57::245].51972  \
 	dns QUERY,NOERROR,51420,qr|rd|ra \
 	1 google.com,IN,A \
 	1 google.com,IN,A,299,172.217.20.46 0 \
-	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0]

--- a/plugins/ipcrypt/test3.gold
+++ b/plugins/ipcrypt/test3.gold
@@ -716,12 +716,10 @@
 	[2a01:3f0:0:57::245].51972 [2001:4860:4860::8888].53  \
 	dns QUERY,NOERROR,51420,rd|ad \
 	1 google.com,IN,A 0 0 \
-	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0]
 [103] 2018-11-27 15:52:00.428453 [#1 test3.pcap.20181127.155200.414188 4095] \
 	[2001:4860:4860::8888].53 [2a01:3f0:0:57::245].51972  \
 	dns QUERY,NOERROR,51420,qr|rd|ra \
 	1 google.com,IN,A \
 	1 google.com,IN,A,299,172.217.20.46 0 \
-	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0]

--- a/plugins/royparse/royparse.c
+++ b/plugins/royparse/royparse.c
@@ -48,6 +48,7 @@
 #include <arpa/inet.h>
 #include <arpa/nameser.h>
 #include <pcap.h>
+#include <ldns/ldns.h>
 
 static logerr_t* logerr;
 static char*     opt_q = 0;
@@ -175,49 +176,54 @@ void royparse_output(const char* descr, iaddr from, iaddr to, uint8_t proto, uns
     const u_char* payload, unsigned payloadlen)
 {
     if (flags & DNSCAP_OUTPUT_ISDNS) {
-        int    rrmax;
-        ns_msg msg;
-        ns_rr  rr;
-        if (ns_initparse(payload, payloadlen, &msg) < 0) {
+        ldns_buffer* buf = ldns_buffer_new(512);
+        if (!buf) {
+            logerr("out of memmory\n");
+            exit(1);
+        }
+
+        ldns_pkt* pkt;
+        if (ldns_wire2pkt(&pkt, payload, payloadlen) != LDNS_STATUS_OK) {
             fprintf(r_out, "ERR\n");
+            ldns_buffer_free(buf);
             return;
         }
-        if (ns_msg_getflag(msg, ns_f_qr) != 0 && sport == 53) {
-            fprintf(r_out, "%cD_", ns_msg_getflag(msg, ns_f_rd) ? 'R' : 'N');
+        if (ldns_pkt_qr(pkt) && sport == 53) {
+            fprintf(r_out, "%cD_", ldns_pkt_rd(pkt) ? 'R' : 'N');
 
-            switch (ns_msg_getflag(msg, ns_f_opcode)) {
-            case ns_o_query:
+            switch (ldns_pkt_get_opcode(pkt)) {
+            case LDNS_PACKET_QUERY:
                 fprintf(r_out, "QUERY");
                 break;
-            case ns_o_notify:
+            case LDNS_PACKET_NOTIFY:
                 fprintf(r_out, "NOTIFY");
                 break;
-            case ns_o_update:
+            case LDNS_PACKET_UPDATE:
                 fprintf(r_out, "UPDATE");
                 break;
             default:
                 fprintf(r_out, "ELSE");
             }
 
-            fprintf(r_out, "_%u_%cA_", ns_msg_count(msg, ns_s_an) ? 1 : 0, ns_msg_getflag(msg, ns_f_aa) ? 'A' : 'N');
+            fprintf(r_out, "_%u_%cA_", ldns_pkt_ancount(pkt) ? 1 : 0, ldns_pkt_aa(pkt) ? 'A' : 'N');
 
-            switch (ns_msg_getflag(msg, ns_f_rcode)) {
-            case ns_r_noerror:
+            switch (ldns_pkt_get_rcode(pkt)) {
+            case LDNS_RCODE_NOERROR:
                 fprintf(r_out, "NOERROR");
                 break;
-            case ns_r_formerr:
+            case LDNS_RCODE_FORMERR:
                 fprintf(r_out, "FORMERR");
                 break;
-            case ns_r_nxdomain:
+            case LDNS_RCODE_NXDOMAIN:
                 fprintf(r_out, "NXDOMAIN");
                 break;
-            case ns_r_notimpl:
+            case LDNS_RCODE_NOTIMPL:
                 fprintf(r_out, "NOTIMP");
                 break;
-            case ns_r_refused:
+            case LDNS_RCODE_REFUSED:
                 fprintf(r_out, "REFUSED");
                 break;
-            case ns_r_notauth:
+            case LDNS_RCODE_NOTAUTH:
                 fprintf(r_out, "NOTAUTH");
                 break;
             default:
@@ -226,39 +232,41 @@ void royparse_output(const char* descr, iaddr from, iaddr to, uint8_t proto, uns
 
             fprintf(r_out, " %s,", royparse_ia_str(to));
 
-            if (ns_msg_count(msg, ns_s_qd) > 0) {
-                if (ns_parserr(&msg, ns_s_qd, 0, &rr) == 0) {
-                    royparse_normalize(ns_rr_name(rr));
-                    fprintf(r_out, "%s%s,%u", ns_rr_name(rr), (ns_rr_name(rr)[0] == '.') ? "" : ".", ns_rr_type(rr));
-                } else
+            ldns_rr_list* qds = ldns_pkt_question(pkt);
+            ldns_rr*      qd;
+            if (qds && (qd = ldns_rr_list_rr(qds, 0))) {
+                if (ldns_rdf2buffer_str(buf, ldns_rr_owner(qd)) == LDNS_STATUS_OK) {
+                    royparse_normalize((char*)ldns_buffer_begin(buf));
+                    fprintf(r_out, "%.*s%s,%u", (int)ldns_buffer_position(buf) - 1, (char*)ldns_buffer_begin(buf),
+                        ((char*)ldns_buffer_begin(buf))[0] == '.' ? "" : ".",
+                        ldns_rr_get_type(qd));
+                } else {
                     fprintf(r_out, "ERR,ERR");
+                }
             } else
                 fprintf(r_out, ",");
 
-            fprintf(r_out, ",%ld,%s%s%s%s", (long)ns_msg_size(msg), ns_msg_id(msg) < 256 ? "-L" : "",
-                ns_msg_getflag(msg, ns_f_tc) ? "-TC" : "",
-                ns_msg_getflag(msg, ns_f_ad) ? "-AD" : "",
-                ns_msg_getflag(msg, ns_f_cd) ? "-CD" : "");
-            rrmax = ns_msg_count(msg, ns_s_ar);
-
-            while (rrmax > 0) {
-                rrmax--;
-                if (ns_parserr(&msg, ns_s_ar, rrmax, &rr) == 0) {
-                    if (ns_rr_type(rr) == ns_t_opt) {
-                        fprintf(r_out, "-%c", (u_long)ns_rr_ttl(rr) & NS_OPT_DNSSEC_OK ? 'D' : 'E');
-                        break;
-                    }
-                }
+            fprintf(r_out, ",%zu,%s%s%s%s", ldns_pkt_size(pkt), ldns_pkt_id(pkt) < 256 ? "-L" : "",
+                ldns_pkt_tc(pkt) ? "-TC" : "",
+                ldns_pkt_ad(pkt) ? "-AD" : "",
+                ldns_pkt_cd(pkt) ? "-CD" : "");
+            if (ldns_pkt_edns(pkt)) {
+                fprintf(r_out, "-%c", ldns_pkt_edns_do(pkt) ? 'D' : 'E');
             }
             fprintf(r_out, "\n");
-        } else if (opt_q != 0 && ns_msg_getflag(msg, ns_f_qr) == 0 && dport == 53) {
+        } else if (opt_q != 0 && !ldns_pkt_qr(pkt) && dport == 53) {
             struct pcap_pkthdr h;
-            if (flags & DNSCAP_OUTPUT_ISLAYER)
+            if (flags & DNSCAP_OUTPUT_ISLAYER) {
+                ldns_pkt_free(pkt);
+                ldns_buffer_free(buf);
                 return;
+            }
             memset(&h, 0, sizeof h);
             h.ts  = ts;
             h.len = h.caplen = olen;
             pcap_dump((u_char*)q_out, &h, pkt_copy);
         }
+        ldns_pkt_free(pkt);
+        ldns_buffer_free(buf);
     }
 }

--- a/plugins/rssm/Makefile.am
+++ b/plugins/rssm/Makefile.am
@@ -5,14 +5,14 @@ CLEANFILES = $(srcdir)/hashtbl.c \
 AM_CFLAGS = -I$(srcdir) \
     -I$(top_srcdir)/src \
     -I$(top_srcdir)/isc \
-    $(SECCOMPFLAGS)
+    $(SECCOMPFLAGS) \
+    $(libldns_CFLAGS)
 
-if HAVE_LDNS
 pkglib_LTLIBRARIES = rssm.la
 rssm_la_SOURCES = rssm.c
 nodist_rssm_la_SOURCES = hashtbl.c
 BUILT_SOURCES = hashtbl.c
-rssm_la_LDFLAGS = -module -avoid-version
+rssm_la_LDFLAGS = -module -avoid-version $(libldns_LIBS)
 TESTS = test1.sh test2.sh test3.sh test4.sh test5.sh
 EXTRA_DIST = $(TESTS) test1.gold test2.gold dnscap-rssm-rssac002.1.in \
   test3.gold test5.gold
@@ -27,7 +27,6 @@ gcov-local:
 	for src in $(rssm_la_SOURCES) $(nodist_rssm_la_SOURCES); do \
 	  gcov -o .libs -l -r -s "$(srcdir)" "$$src"; \
 	done
-endif
 endif
 
 hashtbl.c: $(top_srcdir)/src/hashtbl.c

--- a/plugins/rzkeychange/Makefile.am
+++ b/plugins/rzkeychange/Makefile.am
@@ -4,12 +4,12 @@ CLEANFILES = *.gcda *.gcno *.gcov
 AM_CFLAGS = -I$(srcdir) \
     -I$(top_srcdir)/src \
     -I$(top_srcdir)/isc \
-    $(SECCOMPFLAGS)
+    $(SECCOMPFLAGS) \
+    $(libldns_CFLAGS)
 
-if HAVE_LDNS
 pkglib_LTLIBRARIES = rzkeychange.la
 rzkeychange_la_SOURCES = rzkeychange.c
-rzkeychange_la_LDFLAGS = -module -avoid-version $(LIBRARY_VERSION)
+rzkeychange_la_LDFLAGS = -module -avoid-version $(libldns_LIBS)
 
 TESTS = test1.sh
 EXTRA_DIST = $(TESTS)
@@ -20,5 +20,4 @@ gcov-local:
 	for src in $(rzkeychange_la_SOURCES); do \
 	  gcov -o .libs -l -r -s "$(srcdir)" "$$src"; \
 	done
-endif
 endif

--- a/plugins/txtout/Makefile.am
+++ b/plugins/txtout/Makefile.am
@@ -4,11 +4,11 @@ CLEANFILES = *.gcda *.gcno *.gcov
 AM_CFLAGS = -I$(srcdir) \
     -I$(top_srcdir)/src \
     -I$(top_srcdir)/isc \
-    $(SECCOMPFLAGS)
+    $(SECCOMPFLAGS) $(libldns_CFLAGS)
 
 pkglib_LTLIBRARIES = txtout.la
 txtout_la_SOURCES = txtout.c
-txtout_la_LDFLAGS = -module -avoid-version
+txtout_la_LDFLAGS = -module -avoid-version $(libldns_LIBS)
 
 TESTS = test1.sh
 EXTRA_DIST = $(TESTS)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -7,7 +7,8 @@ AM_CFLAGS = -I$(srcdir) \
     -I$(top_srcdir) \
     $(SECCOMPFLAGS) \
     $(PTHREAD_CFLAGS) \
-    $(libcrypto_CFLAGS)
+    $(libcrypto_CFLAGS) \
+    $(libldns_CFLAGS)
 
 EXTRA_DIST = dnscap.1.in
 
@@ -21,7 +22,7 @@ dist_dnscap_SOURCES = args.h bpft.h daemon.h dnscap_common.h dnscap.h \
     dump_cbor.h dump_cds.h dump_dns.h dumper.h endpoint.h hashtbl.h iaddr.h \
     log.h network.h options.h pcaps.h sig.h tcpstate.h tcpreasm.h memzero.h \
     pcap-thread/pcap_thread.h pcap-thread/pcap_thread_ext_frag.h
-dnscap_LDADD = $(PTHREAD_LIBS) $(libcrypto_LIBS)
+dnscap_LDADD = $(PTHREAD_LIBS) $(libcrypto_LIBS) $(libldns_LIBS)
 
 man1_MANS = dnscap.1
 

--- a/src/args.c
+++ b/src/args.c
@@ -527,9 +527,7 @@ void parse_args(int argc, char* argv[])
             break;
         case 'x':
         /* FALLTHROUGH */
-        case 'X':
-#if HAVE_NS_INITPARSE && HAVE_NS_PARSERR && HAVE_NS_SPRINTRR
-        {
+        case 'X': {
             int         i;
             myregex_ptr myregex = calloc(1, sizeof *myregex);
             assert(myregex != NULL);
@@ -543,18 +541,7 @@ void parse_args(int argc, char* argv[])
             }
             myregex->not = (ch == 'X');
             APPEND(myregexes, myregex, link);
-        }
-#else
-            /*
-             * -x and -X options require libbind because
-             * the code calls ns_initparse(), ns_parserr(),
-             * and ns_sprintrr()
-             */
-            fprintf(stderr, "%s must be compiled with libbind to use the -x or -X option.\n",
-                ProgramName);
-            exit(1);
-#endif
-        break;
+        } break;
         case 'B': {
             struct tm tm;
             memset(&tm, '\0', sizeof(tm));
@@ -815,12 +802,8 @@ void parse_args(int argc, char* argv[])
     }
 
     if (options.reassemble_tcp_bfbparsedns) {
-#if HAVE_NS_INITPARSE
         if (!options.reassemble_tcp) {
             usage("can't do byte for byte parsing of DNS without reassemble_tcp=yes");
         }
-#else
-        usage("not compiled with libbind, needed for reassemble_tcp_bfbparsedns=yes");
-#endif
     }
 }

--- a/src/bpft.c
+++ b/src/bpft.c
@@ -37,6 +37,8 @@
 #include "bpft.h"
 #include "iaddr.h"
 
+#include <ldns/ldns.h>
+
 void prepare_bpft(void)
 {
     unsigned  udp10_mbs, udp10_mbc, udp11_mbc; //udp11_mbs
@@ -55,10 +57,10 @@ void prepare_bpft(void)
     }
     if ((msg_wanted & MSG_UPDATE) != 0) {
         if ((msg_wanted & (MSG_QUERY | MSG_NOTIFY)) == 0)
-            udp10_mbs |= (ns_o_update << UDP10_OP_SHIFT);
+            udp10_mbs |= (LDNS_PACKET_UPDATE << UDP10_OP_SHIFT);
     } else if ((msg_wanted & MSG_NOTIFY) != 0) {
         if ((msg_wanted & (MSG_QUERY | MSG_UPDATE)) == 0)
-            udp10_mbs |= (ns_o_notify << UDP10_OP_SHIFT);
+            udp10_mbs |= (LDNS_PACKET_NOTIFY << UDP10_OP_SHIFT);
     } else if ((msg_wanted & MSG_QUERY) != 0) {
         udp10_mbc |= UDP10_OP_MASK;
     }

--- a/src/dnscap.1.in
+++ b/src/dnscap.1.in
@@ -505,13 +505,11 @@ if the sequence is outside the TCP window.
 The default is zero which means it will reset the state as soon as the
 segment buffer is full.
 .It reassemble_tcp_bfbparsedns=yes
-Enable an experimental additional layer of reassemble that uses libbind to
+Enable an experimental additional layer of reassemble that uses LDNS to
 parse the payload before accepting it.
 If the DNS is invalid it will move 2 bytes within the payload and treat it
 as a new payload, taking the DNS length again and restart the process.
-Requires that
-.Nm
-was compiled with libbind and
+Requires
 .Ar reassemble_tcp=yes .
 .It bpf_hosts_apply_all=yes
 This changes the BPF generation so that any host restriction will come

--- a/src/dnscap.c
+++ b/src/dnscap.c
@@ -133,7 +133,6 @@ int main(int argc, char* argv[])
 #endif
 #endif
 
-    res_init();
     parse_args(argc, argv);
     gettimeofday(&now, 0);
     if (!only_offline_pcaps && start_time) {

--- a/src/dnscap.h
+++ b/src/dnscap.h
@@ -127,7 +127,6 @@
 #include <netdb.h>
 #include <pcap.h>
 #include <regex.h>
-#include <resolv.h>
 #include <signal.h>
 #include <stdarg.h>
 #include <stdio.h>
@@ -168,12 +167,12 @@
 
 #define ERR_TRUNC 0x0001
 #define ERR_RCODE_BASE 0x0002
-#define ERR_NO (ERR_RCODE_BASE << ns_r_noerror)
-#define ERR_FORMERR (ERR_RCODE_BASE << ns_r_formerr)
-#define ERR_SERVFAIL (ERR_RCODE_BASE << ns_r_servfail)
-#define ERR_NXDOMAIN (ERR_RCODE_BASE << ns_r_nxdomain)
-#define ERR_NOTIMPL (ERR_RCODE_BASE << ns_r_notimpl)
-#define ERR_REFUSED (ERR_RCODE_BASE << ns_r_refused)
+#define ERR_NO (ERR_RCODE_BASE << 0)
+#define ERR_FORMERR (ERR_RCODE_BASE << 1)
+#define ERR_SERVFAIL (ERR_RCODE_BASE << 2)
+#define ERR_NXDOMAIN (ERR_RCODE_BASE << 3)
+#define ERR_NOTIMPL (ERR_RCODE_BASE << 4)
+#define ERR_REFUSED (ERR_RCODE_BASE << 5)
 #define ERR_YES (0xffffffff & ~ERR_NO)
 
 #define END_INITIATOR 0x0001

--- a/src/dump_dns.c
+++ b/src/dump_dns.c
@@ -41,357 +41,287 @@
 
 #include "dnscap_common.h"
 
-#include <sys/types.h>
-#include <stdio.h>
 #include "dump_dns.h"
 #include "network.h"
 #include "tcpstate.h"
 
-#if HAVE_NS_INITPARSE && HAVE_NS_PARSERR && HAVE_NS_NAME_UNCOMPRESS && HAVE_P_RCODE
-
-#ifdef __linux__
-#define _GNU_SOURCE
-#ifndef __USE_POSIX199309
-#define __USE_POSIX199309
+#include <ldns/ldns.h>
+#ifdef HAVE_ENDIAN_H
+#include <endian.h>
+#else
+#ifdef HAVE_SYS_ENDIAN_H
+#include <sys/endian.h>
+#else
+#ifdef HAVE_MACHINE_ENDIAN_H
+#include <machine/endian.h>
 #endif
 #endif
-
-#ifdef __SVR4
-#define u_int32_t uint32_t
-#define u_int16_t uint16_t
 #endif
-
-#include <sys/socket.h>
-
 #include <netinet/in.h>
-#include <arpa/inet.h>
-#include <arpa/nameser.h>
-#if HAVE_ARPA_NAMESER_COMPAT_H
-#include <arpa/nameser_compat.h>
-#endif
 
-#include <assert.h>
-#include <errno.h>
-#include <fcntl.h>
-#include <resolv.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <signal.h>
-#include <string.h>
-#include <unistd.h>
-
-#ifdef p_rcode
-#undef p_rcode
-#endif
-#define p_rcode __p_rcode
-extern const char* p_rcode(int rcode);
-
-static const char* p_opcode(int opcode);
-static void        dump_dns_sect(ns_msg*, ns_sect, FILE*, const char*);
-static void        dump_dns_rr(ns_msg*, ns_rr*, ns_sect, FILE*);
-
-#define MY_GET16(s, cp)                                         \
-    do {                                                        \
-        register const u_char* t_cp = (const u_char*)(cp);      \
-        (s)                         = ((u_int16_t)t_cp[0] << 8) \
-              | ((u_int16_t)t_cp[1]);                           \
-        (cp) += NS_INT16SZ;                                     \
-    } while (0)
-
-#define MY_GET32(l, cp)                                          \
-    do {                                                         \
-        register const u_char* t_cp = (const u_char*)(cp);       \
-        (l)                         = ((u_int32_t)t_cp[0] << 24) \
-              | ((u_int32_t)t_cp[1] << 16)                       \
-              | ((u_int32_t)t_cp[2] << 8)                        \
-              | ((u_int32_t)t_cp[3]);                            \
-        (cp) += NS_INT32SZ;                                      \
-    } while (0)
-
-#include "dump_dns.h"
-
-void dump_dns(const u_char* payload, size_t paylen,
-    FILE* trace, const char* endline)
+static inline uint16_t _need16(const void* ptr)
 {
-    u_int        opcode, rcode, id;
+    uint16_t v;
+    memcpy(&v, ptr, sizeof(v));
+    return be16toh(v);
+}
+
+static void dump_dns_rr(ldns_rr* rr, FILE* trace, ldns_buffer* lbuf, bool qsect)
+{
+    size_t    rdlen, i;
+    ldns_rdf* rdf;
+
+    // owner
+    ldns_buffer_clear(lbuf);
+    if (ldns_rdf2buffer_str(lbuf, ldns_rr_owner(rr)) != LDNS_STATUS_OK) {
+        goto error;
+    }
+    fprintf(trace, "%.*s", (int)ldns_buffer_position(lbuf) - 1, (char*)ldns_buffer_begin(lbuf));
+
+    // class
+    ldns_buffer_clear(lbuf);
+    if (ldns_rr_class2buffer_str(lbuf, ldns_rr_get_class(rr)) != LDNS_STATUS_OK) {
+        goto error;
+    }
+    fprintf(trace, ",%s", (char*)ldns_buffer_begin(lbuf));
+
+    // type
+    ldns_buffer_clear(lbuf);
+    if (ldns_rr_type2buffer_str(lbuf, ldns_rr_get_type(rr)) != LDNS_STATUS_OK) {
+        goto error;
+    }
+    fprintf(trace, ",%s", (char*)ldns_buffer_begin(lbuf));
+
+    if (qsect)
+        return;
+
+    fprintf(trace, ",%u", ldns_rr_ttl(rr));
+    switch (ldns_rr_get_type(rr)) {
+    case LDNS_RR_TYPE_SOA:
+        for (i = 0; i < 2; i++) {
+            if (!(rdf = ldns_rr_rdf(rr, i))) {
+                goto error;
+            }
+            ldns_buffer_clear(lbuf);
+            if (ldns_rdf2buffer_str(lbuf, rdf) != LDNS_STATUS_OK) {
+                goto error;
+            }
+            fprintf(trace, ",%.*s", (int)ldns_buffer_position(lbuf) - 1, (char*)ldns_buffer_begin(lbuf));
+        }
+        for (; i < 7; i++) {
+            if (!(rdf = ldns_rr_rdf(rr, i))) {
+                goto error;
+            }
+            ldns_buffer_clear(lbuf);
+            if (ldns_rdf2buffer_str(lbuf, rdf) != LDNS_STATUS_OK) {
+                goto error;
+            }
+            fprintf(trace, ",%s", (char*)ldns_buffer_begin(lbuf));
+        }
+        break;
+
+    case LDNS_RR_TYPE_A:
+    case LDNS_RR_TYPE_AAAA:
+    case LDNS_RR_TYPE_MX:
+        if (!(rdf = ldns_rr_rdf(rr, 0))) {
+            goto error;
+        }
+        ldns_buffer_clear(lbuf);
+        if (ldns_rdf2buffer_str(lbuf, rdf) != LDNS_STATUS_OK) {
+            goto error;
+        }
+        fprintf(trace, ",%s", (char*)ldns_buffer_begin(lbuf));
+        break;
+
+    case LDNS_RR_TYPE_NS:
+    case LDNS_RR_TYPE_PTR:
+    case LDNS_RR_TYPE_CNAME:
+        if (!(rdf = ldns_rr_rdf(rr, 0))) {
+            goto error;
+        }
+        ldns_buffer_clear(lbuf);
+        if (ldns_rdf2buffer_str(lbuf, rdf) != LDNS_STATUS_OK) {
+            goto error;
+        }
+        fprintf(trace, ",%.*s", (int)ldns_buffer_position(lbuf) - 1, (char*)ldns_buffer_begin(lbuf));
+        break;
+
+    default:
+        goto error;
+    }
+    return;
+
+error:
+    for (rdlen = 0, i = 0, rdf = ldns_rr_rdf(rr, i); rdf; rdf = ldns_rr_rdf(rr, ++i)) {
+        rdlen += ldns_rdf_size(rdf);
+    }
+    fprintf(trace, ",[%zu]", rdlen);
+}
+
+static void dump_dns_sect(ldns_rr_list* rrs, FILE* trace, const char* endline, ldns_buffer* lbuf, bool qsect, bool ansect, ldns_pkt* pkt)
+{
+    size_t      rrnum, rrmax;
+    const char* sep;
+
+    if (ansect && ldns_pkt_edns(pkt)) {
+        rrmax = ldns_rr_list_rr_count(rrs);
+        fprintf(trace, " %s%zu", endline, rrmax + 1);
+        sep = "";
+        for (rrnum = 0; rrnum < rrmax; rrnum++) {
+            fprintf(trace, " %s", sep);
+            dump_dns_rr(ldns_rr_list_rr(rrs, rrnum), trace, lbuf, qsect);
+            sep = endline;
+        }
+        ldns_rdf* edns_data = ldns_pkt_edns_data(pkt);
+        fprintf(trace, " %s.,%u,%u,0,edns0[len=%zu,UDP=%u,ver=%u,rcode=%u,DO=%u,z=%u]",
+            sep, ldns_pkt_edns_udp_size(pkt), ldns_pkt_edns_udp_size(pkt),
+            edns_data ? ldns_rdf_size(edns_data) : 0,
+            ldns_pkt_edns_udp_size(pkt),
+            ldns_pkt_edns_version(pkt),
+            ldns_pkt_edns_extended_rcode(pkt),
+            ldns_pkt_edns_do(pkt) ? 1 : 0,
+            ldns_pkt_edns_z(pkt));
+        if (edns_data) {
+            size_t   len = ldns_rdf_size(edns_data);
+            uint8_t* d   = ldns_rdf_data(edns_data);
+
+            while (len >= 4) {
+                uint16_t opcode = _need16(d);
+                uint16_t oplen  = _need16(d + 2);
+                len -= 4;
+                d += 4;
+
+                if (oplen > len) {
+                    break;
+                }
+                switch (opcode) {
+                case 8: {
+                    if (oplen >= 4) {
+                        uint16_t        family            = _need16(d);
+                        uint8_t         source_prefix_len = *(d + 2), scope_prefix_len = *(d + 3);
+                        char            addr[(INET_ADDRSTRLEN < INET6_ADDRSTRLEN ? INET6_ADDRSTRLEN : INET_ADDRSTRLEN) + 1] = { 0 };
+                        struct in_addr  in4                                                                                 = { .s_addr = INADDR_ANY };
+                        struct in6_addr in6                                                                                 = IN6ADDR_ANY_INIT;
+                        void*           in                                                                                  = 0;
+                        int             af;
+
+                        switch (family) {
+                        case 1: {
+                            memcpy(&in4.s_addr, d + 4, oplen - 4 > sizeof(in4.s_addr) ? sizeof(in4.s_addr) : oplen - 4);
+                            in = &in4;
+                            af = AF_INET;
+                            break;
+                        }
+                        case 2: {
+                            memcpy(&in6.s6_addr, d + 4, oplen - 4 > sizeof(in6.s6_addr) ? sizeof(in6.s6_addr) : oplen - 4);
+                            in = &in6;
+                            af = AF_INET6;
+                            break;
+                        }
+                        default:
+                            break;
+                        }
+
+                        if (!in || !inet_ntop(af, in, addr, sizeof(addr) - 1)) {
+                            strncpy(addr, "invalid", sizeof(addr) - 1);
+                        }
+
+                        fprintf(trace, ",edns0opt[ECS,family=%u,source=%u,scope=%u,addr=%s]",
+                            family, source_prefix_len, scope_prefix_len, addr);
+                        break;
+                    }
+                }
+
+                default:
+                    fprintf(trace, ",edns0opt[code=%u,codelen=%u]", opcode, oplen);
+                    break;
+                }
+
+                len -= oplen;
+                d += oplen;
+            }
+        }
+        return;
+    }
+
+    rrmax = ldns_rr_list_rr_count(rrs);
+    if (rrmax == 0) {
+        fputs(" 0", trace);
+        return;
+    }
+    fprintf(trace, " %s%zu", endline, rrmax);
+    sep = "";
+    for (rrnum = 0; rrnum < rrmax; rrnum++) {
+        fprintf(trace, " %s", sep);
+        dump_dns_rr(ldns_rr_list_rr(rrs, rrnum), trace, lbuf, qsect);
+        sep = endline;
+    }
+}
+
+void dump_dns(const u_char* payload, size_t paylen, FILE* trace, const char* endline)
+{
     const char*  sep;
-    ns_msg       msg;
     tcpstate_ptr tcpstate;
+    ldns_pkt*    pkt  = 0;
+    ldns_buffer* lbuf = 0;
+    ldns_status  ret;
 
     fprintf(trace, " %sdns ", endline);
-    if (ns_initparse(payload, paylen, &msg) < 0) {
+    if ((ret = ldns_wire2pkt(&pkt, payload, paylen)) != LDNS_STATUS_OK) {
         /* DNS message may have padding, try get actual size */
-        if (errno == EMSGSIZE) {
-            size_t dnslen = calcdnslen(payload, paylen);
-            if (dnslen > 0 && dnslen < paylen && ns_initparse(payload, dnslen, &msg) < 0) {
-                fputs(strerror(errno), trace);
+        size_t dnslen = calcdnslen(payload, paylen);
+        if (dnslen > 0 && dnslen < paylen) {
+            if ((ret = ldns_wire2pkt(&pkt, payload, dnslen)) != LDNS_STATUS_OK) {
+                fputs(ldns_get_errorstr_by_id(ret), trace);
                 if ((tcpstate = tcpstate_getcurr()))
                     tcpstate_reset(tcpstate, strerror(errno));
                 return;
             }
         } else {
-            fputs(strerror(errno), trace);
+            fputs(ldns_get_errorstr_by_id(ret), trace);
             if ((tcpstate = tcpstate_getcurr()))
                 tcpstate_reset(tcpstate, strerror(errno));
             return;
         }
     }
-    opcode = ns_msg_getflag(msg, ns_f_opcode);
-    rcode  = ns_msg_getflag(msg, ns_f_rcode);
-    id     = ns_msg_id(msg);
-    fprintf(trace, "%s,%s,%u", p_opcode(opcode), p_rcode(rcode), id);
-    sep = ",";
+
+    if (!(lbuf = ldns_buffer_new(512))) {
+        fprintf(stderr, "%s: out of memory", ProgramName);
+        exit(1);
+    }
+
+    if (ldns_pkt_opcode2buffer_str(lbuf, ldns_pkt_get_opcode(pkt)) != LDNS_STATUS_OK) {
+        fprintf(stderr, "%s: unable to covert opcode to str", ProgramName);
+        exit(1);
+    }
+    fprintf(trace, "%s,", (char*)ldns_buffer_begin(lbuf));
+    ldns_buffer_clear(lbuf);
+    if (ldns_pkt_rcode2buffer_str(lbuf, ldns_pkt_get_rcode(pkt)) != LDNS_STATUS_OK) {
+        fprintf(stderr, "%s: unable to covert rcode to str", ProgramName);
+        exit(1);
+    }
+    fprintf(trace, "%s,%u,", (char*)ldns_buffer_begin(lbuf), ldns_pkt_id(pkt));
+
+    sep = "";
 #define FLAG(t, f)                      \
-    if (ns_msg_getflag(msg, f)) {       \
+    if (f) {                            \
         fprintf(trace, "%s%s", sep, t); \
         sep = "|";                      \
     }
-    FLAG("qr", ns_f_qr);
-    FLAG("aa", ns_f_aa);
-    FLAG("tc", ns_f_tc);
-    FLAG("rd", ns_f_rd);
-    FLAG("ra", ns_f_ra);
-    FLAG("z", ns_f_z);
-    FLAG("ad", ns_f_ad);
-    FLAG("cd", ns_f_cd);
+    FLAG("qr", ldns_pkt_qr(pkt));
+    FLAG("aa", ldns_pkt_aa(pkt));
+    FLAG("tc", ldns_pkt_tc(pkt));
+    FLAG("rd", ldns_pkt_rd(pkt));
+    FLAG("ra", ldns_pkt_ra(pkt));
+    FLAG("z", LDNS_Z_WIRE(payload));
+    FLAG("ad", ldns_pkt_ad(pkt));
+    FLAG("cd", ldns_pkt_cd(pkt));
 #undef FLAG
-    dump_dns_sect(&msg, ns_s_qd, trace, endline);
-    dump_dns_sect(&msg, ns_s_an, trace, endline);
-    dump_dns_sect(&msg, ns_s_ns, trace, endline);
-    dump_dns_sect(&msg, ns_s_ar, trace, endline);
+    dump_dns_sect(ldns_pkt_question(pkt), trace, endline, lbuf, true, false, 0);
+    dump_dns_sect(ldns_pkt_answer(pkt), trace, endline, lbuf, false, false, 0);
+    dump_dns_sect(ldns_pkt_authority(pkt), trace, endline, lbuf, false, false, 0);
+    dump_dns_sect(ldns_pkt_additional(pkt), trace, endline, lbuf, false, true, pkt);
+
+    ldns_buffer_free(lbuf);
+    ldns_pkt_free(pkt);
 }
-
-static void
-dump_dns_sect(ns_msg* msg, ns_sect sect, FILE* trace, const char* endline)
-{
-    int          rrnum, rrmax;
-    const char*  sep;
-    ns_rr        rr;
-    tcpstate_ptr tcpstate;
-
-    rrmax = ns_msg_count(*msg, sect);
-    if (rrmax == 0) {
-        fputs(" 0", trace);
-        return;
-    }
-    fprintf(trace, " %s%d", endline, rrmax);
-    sep = "";
-    for (rrnum = 0; rrnum < rrmax; rrnum++) {
-        if (ns_parserr(msg, sect, rrnum, &rr)) {
-            fprintf(trace, " %s", strerror(errno));
-            if ((tcpstate = tcpstate_getcurr()))
-                tcpstate_reset(tcpstate, strerror(errno));
-            return;
-        }
-        fprintf(trace, " %s", sep);
-        dump_dns_rr(msg, &rr, sect, trace);
-        sep = endline;
-    }
-}
-
-static void
-dump_dns_rr(ns_msg* msg, ns_rr* rr, ns_sect sect, FILE* trace)
-{
-    char buf[NS_MAXDNAME];
-    u_int class, type;
-    const u_char* rd;
-    u_int32_t     soa[5];
-    u_int16_t     mx;
-    int           n;
-
-    memset(buf, 0, sizeof(buf));
-    class = ns_rr_class(*rr);
-    type  = ns_rr_type(*rr);
-    fprintf(trace, "%s,%s,%s",
-        ns_rr_name(*rr),
-        p_class(class),
-        p_type(type));
-    if (sect == ns_s_qd)
-        return;
-    fprintf(trace, ",%lu", (u_long)ns_rr_ttl(*rr));
-    rd = ns_rr_rdata(*rr);
-    switch (type) {
-    case ns_t_soa:
-        n = ns_name_uncompress(ns_msg_base(*msg), ns_msg_end(*msg),
-            rd, buf, sizeof buf);
-        if (n < 0)
-            goto error;
-        putc(',', trace);
-        fputs(buf, trace);
-        rd += n;
-        n = ns_name_uncompress(ns_msg_base(*msg), ns_msg_end(*msg),
-            rd, buf, sizeof buf);
-        if (n < 0)
-            goto error;
-        putc(',', trace);
-        fputs(buf, trace);
-        rd += n;
-        if (ns_msg_end(*msg) - rd < 5 * NS_INT32SZ)
-            goto error;
-        for (n = 0; n < 5; n++)
-            MY_GET32(soa[n], rd);
-        snprintf(buf, sizeof(buf), "%u,%u,%u,%u,%u",
-            soa[0], soa[1], soa[2], soa[3], soa[4]);
-        break;
-    case ns_t_a:
-        if (ns_msg_end(*msg) - rd < 4)
-            goto error;
-        inet_ntop(AF_INET, rd, buf, sizeof buf);
-        break;
-    case ns_t_aaaa:
-        if (ns_msg_end(*msg) - rd < 16)
-            goto error;
-        inet_ntop(AF_INET6, rd, buf, sizeof buf);
-        break;
-    case ns_t_mx:
-        if (ns_msg_end(*msg) - rd < 2)
-            goto error;
-        MY_GET16(mx, rd);
-        fprintf(trace, ",%u", mx);
-    /* FALLTHROUGH */
-    case ns_t_ns:
-    case ns_t_ptr:
-    case ns_t_cname:
-        n = ns_name_uncompress(ns_msg_base(*msg), ns_msg_end(*msg),
-            rd, buf, sizeof buf);
-        if (n < 0)
-            goto error;
-        break;
-    /*
-     * GGM 2014/09/04 deal with edns0 a bit more clearly
-     */
-    case ns_t_opt: {
-        u_long  edns0csize;
-        u_short edns0version;
-        u_short edns0rcode;
-        u_char  edns0dobit;
-        u_char  edns0z;
-
-        /* class encodes client UDP size accepted */
-        edns0csize = (u_long)(class);
-
-        /*
-         * the first two bytes of ttl encode edns0 version, and the extended rcode
-         */
-        edns0version = ((u_long)ns_rr_ttl(*rr) & 0x00ff0000) >> 16;
-        edns0rcode   = ((u_long)ns_rr_ttl(*rr) & 0xff000000) >> 24;
-
-        /*
-         *  the next two bytes of ttl encode DO bit as the top bit, and the remainder is the 'z' value
-         */
-        edns0dobit = (u_long)ns_rr_ttl(*rr) & 0x8000 ? '1' : '0';
-        edns0z     = (u_long)ns_rr_ttl(*rr) & 0x7fff;
-
-        /* optlen is the size of the OPT rdata */
-        u_short optlen = ns_rr_rdlen(*rr);
-
-        fprintf(trace, ",edns0[len=%d,UDP=%lu,ver=%d,rcode=%d,DO=%c,z=%d] %c\n\t",
-            optlen, edns0csize, edns0version, edns0rcode, edns0dobit, edns0z, '\\');
-
-        /* if we have any data */
-        while (optlen >= 4) {
-            /* the next two shorts are the edns0 opt code, and the length of the optionsection */
-            u_short edns0optcod;
-            u_short edns0lenopt;
-            MY_GET16(edns0optcod, rd);
-            MY_GET16(edns0lenopt, rd);
-            optlen -= 4;
-            fprintf(trace, "edns0[code=%d,codelen=%d] ", edns0optcod, edns0lenopt);
-
-            /*
-             * Check that the OPTION-LENGTH for this EDNS0 option doesn't
-             * exceed the size of the remaining OPT record rdata.  If it does,
-             * just bail.
-             */
-            if (edns0lenopt > optlen)
-                goto error;
-
-            /*
-             * "pre-consume" edns0lenopt bytes from optlen here because
-             * below we're going to decrement edns0lenopt as we go.
-             * At this point optlen will refer to the size of the remaining
-             * OPT_T rdata after parsing the current option.
-             */
-            optlen -= edns0lenopt;
-
-            /* if we have edns0_client_subnet */
-            if (edns0optcod == 0x08) {
-                if (edns0lenopt < 4)
-                    goto error;
-                u_short afi;
-                MY_GET16(afi, rd);
-                u_short masks;
-                MY_GET16(masks, rd);
-                edns0lenopt -= 4;
-                u_short srcmask = (masks & 0xff00) >> 8;
-                u_short scomask = (masks & 0xff);
-
-                char   buf[128];
-                u_char addr[16];
-                memset(addr, 0, sizeof addr);
-                memcpy(addr, rd, edns0lenopt < sizeof(addr) ? edns0lenopt : sizeof(addr));
-
-                buf[0] = 0;
-                if (afi == 0x1) {
-                    inet_ntop(AF_INET, addr, buf, sizeof buf);
-                } else if (afi == 0x2) {
-                    inet_ntop(AF_INET6, addr, buf, sizeof buf);
-                } else {
-                    fprintf(trace, "unknown AFI %d\n", afi);
-                }
-                fprintf(trace, "edns0_client_subnet=%s/%d (scope %d)", buf[0] ? buf : "<unknown>", srcmask, scomask);
-            }
-            /* increment the rd pointer by the remaining option data size */
-            rd += edns0lenopt;
-        }
-    } break;
-
-    default:
-    error:
-        snprintf(buf, sizeof(buf), "[%u]", ns_rr_rdlen(*rr));
-    }
-    if (buf[0] != '\0') {
-        putc(',', trace);
-        fputs(buf, trace);
-    }
-}
-
-static const char*
-p_opcode(int opcode)
-{
-    static char buf[20];
-    switch (opcode) {
-    case 0:
-        return "QUERY";
-    case 1:
-        return "IQUERY";
-    case 2:
-        return "CQUERYM";
-    case 3:
-        return "CQUERYU";
-    case 4:
-        return "NOTIFY";
-    case 5:
-        return "UPDATE";
-    case 14:
-        return "ZONEINIT";
-    case 15:
-        return "ZONEREF";
-    default:
-        snprintf(buf, sizeof(buf), "OPCODE%d", opcode);
-        return buf;
-    }
-    /* NOTREACHED */
-}
-
-#else
-
-void dump_dns(const u_char* payload, size_t paylen,
-    FILE* trace, const char* endline)
-{
-    (void)payload;
-    (void)paylen;
-    fprintf(trace, " %sNO BINDLIB", endline);
-}
-
-#endif

--- a/src/dump_dns.h
+++ b/src/dump_dns.h
@@ -40,7 +40,8 @@
 #ifndef __dnscap_dump_dns_h
 #define __dnscap_dump_dns_h
 
-void dump_dns(const u_char* payload, size_t paylen,
-    FILE* trace, const char* endline);
+#include <stdio.h>
+
+void dump_dns(const u_char* payload, size_t paylen, FILE* trace, const char* endline);
 
 #endif // __dnscap_dump_dns_h

--- a/src/test/test10.gold
+++ b/src/test/test10.gold
@@ -2,25 +2,21 @@
 	[2a01:3f0:0:57::245].51972 [2001:4860:4860::8888].53  \
 	dns QUERY,NOERROR,51420,rd|ad \
 	1 google.com,IN,A 0 0 \
-	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0]
 [103] 2018-11-27 15:52:00.428453 [#1 dns6.pcap-dist 4095] \
 	[2001:4860:4860::8888].53 [2a01:3f0:0:57::245].51972  \
 	dns QUERY,NOERROR,51420,qr|rd|ra \
 	1 google.com,IN,A \
 	1 google.com,IN,A,299,172.217.20.46 0 \
-	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0]
 [87] 2018-11-27 15:52:00.414188 [#0 dns6.pcap-dist 4095] \
 	[2a01:3f0:0:57::245].51972 [2001:4860:4860::8888].53  \
 	dns QUERY,NOERROR,51420,rd|ad \
 	1 google.com,IN,A 0 0 \
-	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0]
 [103] 2018-11-27 15:52:00.428453 [#1 dns6.pcap-dist 4095] \
 	[2001:4860:4860::8888].53 [2a01:3f0:0:57::245].51972  \
 	dns QUERY,NOERROR,51420,qr|rd|ra \
 	1 google.com,IN,A \
 	1 google.com,IN,A,299,172.217.20.46 0 \
-	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0]

--- a/src/test/test7.gold
+++ b/src/test/test7.gold
@@ -1325,15 +1325,13 @@ Enabling parse_ongoing_tcp and allow_reset_tcpstate
 	[172.17.0.9].48613 [8.8.8.8].53  \
 	dns QUERY,NOERROR,4815,rd|ad \
 	1 google.com,IN,A 0 0 \
-	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,4096,4096,0,edns0[len=0,UDP=4096,ver=0,rcode=0,DO=0,z=0]
 [109] 2017-12-11 13:59:04.956698 [#1 1qtcpnosyn.pcap-dist 4095] \
 	[8.8.8.8].53 [172.17.0.9].48613  \
 	dns QUERY,NOERROR,4815,qr|rd|ra \
 	1 google.com,IN,A \
 	1 google.com,IN,A,47,172.217.22.174 0 \
-	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0]
 [52] 2017-12-11 13:59:04.957247 [#2 1qtcpnosyn.pcap-dist 4095] \
 	[172.17.0.9].48613 [8.8.8.8].53 
 [52] 2017-12-11 13:59:04.960230 [#3 1qtcpnosyn.pcap-dist 4095] \
@@ -1344,8 +1342,7 @@ Enabling parse_ongoing_tcp and allow_reset_tcpstate
 1513000744.960230 8.8.8.8 53 172.17.0.9 48613 6
 [80] 2018-01-10 11:22:41.552406 [#0 do1t-nosyn-1nolen.pcap-dist 4095] \
 	[172.17.0.8].51388 [8.8.8.8].53  \
-	dns QUERY,FORMERR,256 0 0 0 \
-	1639 Message too long
+	dns Label length overflow
 [98] 2018-01-10 11:22:41.555912 [#1 do1t-nosyn-1nolen.pcap-dist 4095] \
 	[8.8.8.8].53 [172.17.0.8].51388  \
 	dns QUERY,NOERROR,59311,qr|rd|ra \

--- a/src/test/test8.gold
+++ b/src/test/test8.gold
@@ -19,8 +19,7 @@
 	dns QUERY,NOERROR,4815,qr|rd|ra \
 	1 google.com,IN,A \
 	1 google.com,IN,A,47,172.217.22.174 0 \
-	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0] \
-	
+	1 .,512,512,0,edns0[len=0,UDP=512,ver=0,rcode=0,DO=0,z=0]
 [52] 2017-12-11 13:59:04.957247 [#6 dnsotcp-many1pkt.pcap-dist 4095] \
 	[172.17.0.9].48613 [8.8.8.8].53 
 [52] 2017-12-11 13:59:04.960230 [#7 dnsotcp-many1pkt.pcap-dist 4095] \


### PR DESCRIPTION
- Fix #11 #133:
  - Remove dependency on libbind, replaced with LDNS
  - Fix memory leak in EDNS0 ECS address parsing
  - Change `-g`'s format of EDNS0 output to be consistent with the rest of the parsable output
    - No more spaces in the output
    - Fix incorrect `\` and extra empty new-line
    - All EDNS0 options are added after `edns0[...]` using comma separation, example: `edns0[],edns0opt[],...`
    - Client Subnet format: `edns0opt[ECS,family=nn,source=nn,scope=nn,addr=...]`
    - Unknown/unsupported code: `edns0opt[code=nn,codelen=nn]`
    - Parsing error messages have changed, they came from libbind, now comes from LDNS
  - `plugins/eventlog`: Use LDNS instead of libbind
  - `plugins/royparse`: Use LDNS instead of libbind
  - `plugins/txtout`: Use LDNS instead of libbind
  - `-X`/`-x` will now match against FQDNs
- `network`: Use inline `memcpy()` and endian functions to get network parameters