### PR TITLE
Endian

### DIFF
--- a/plugins/txtout/txtout.c
+++ b/plugins/txtout/txtout.c
@@ -180,7 +180,7 @@ void txtout_output(const char* descr, iaddr from, iaddr to, uint8_t proto, unsig
         if (flags & DNSCAP_OUTPUT_ISDNS) {
             ldns_pkt* pkt;
 
-            if (ldns_wire2pkt(&pkt, payload, payloadlen) < 0) {
+            if (ldns_wire2pkt(&pkt, payload, payloadlen) != LDNS_STATUS_OK) {
                 if (tcpstate_getcurr && tcpstate_reset)
                     tcpstate_reset(tcpstate_getcurr(), "");
                 return;

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -19,9 +19,10 @@ dnscap_SOURCES = args.c assert.c bpft.c daemon.c dnscap.c dump_cbor.c \
     network.c options.c pcaps.c sig.c tcpstate.c tcpreasm.c memzero.c \
     pcap-thread/pcap_thread.c pcap-thread/pcap_thread_ext_frag.c
 dist_dnscap_SOURCES = args.h bpft.h daemon.h dnscap_common.h dnscap.h \
-    dump_cbor.h dump_cds.h dump_dns.h dumper.h endpoint.h hashtbl.h iaddr.h \
-    log.h network.h options.h pcaps.h sig.h tcpstate.h tcpreasm.h memzero.h \
-    pcap-thread/pcap_thread.h pcap-thread/pcap_thread_ext_frag.h
+  dump_cbor.h dump_cds.h dump_dns.h dumper.h endpoint.h hashtbl.h iaddr.h \
+  log.h network.h options.h pcaps.h sig.h tcpstate.h tcpreasm.h memzero.h \
+  endian_compat.h \
+  pcap-thread/pcap_thread.h pcap-thread/pcap_thread_ext_frag.h
 dnscap_LDADD = $(PTHREAD_LIBS) $(libcrypto_LIBS) $(libldns_LIBS)
 
 man1_MANS = dnscap.1

--- a/src/dump_dns.c
+++ b/src/dump_dns.c
@@ -44,19 +44,9 @@
 #include "dump_dns.h"
 #include "network.h"
 #include "tcpstate.h"
+#include "endian_compat.h"
 
 #include <ldns/ldns.h>
-#ifdef HAVE_ENDIAN_H
-#include <endian.h>
-#else
-#ifdef HAVE_SYS_ENDIAN_H
-#include <sys/endian.h>
-#else
-#ifdef HAVE_MACHINE_ENDIAN_H
-#include <machine/endian.h>
-#endif
-#endif
-#endif
 #include <netinet/in.h>
 
 static inline uint16_t _need16(const void* ptr)

--- a/src/endian_compat.h
+++ b/src/endian_compat.h
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2016-2021, OARC, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __dnscap_endian_compat_h
+#define __dnscap_endian_compat_h
+
+#ifdef HAVE_ENDIAN_H
+#include <endian.h>
+#else
+#ifdef HAVE_SYS_ENDIAN_H
+#include <sys/endian.h>
+#else
+#ifdef HAVE_MACHINE_ENDIAN_H
+#include <machine/endian.h>
+#endif
+#endif
+#endif
+
+#ifdef __APPLE__
+#include <libkern/OSByteOrder.h>
+#define htobe16(x) OSSwapHostToBigInt16(x)
+#define htole16(x) OSSwapHostToLittleInt16(x)
+#define be16toh(x) OSSwapBigToHostInt16(x)
+#define le16toh(x) OSSwapLittleToHostInt16(x)
+#define htobe32(x) OSSwapHostToBigInt32(x)
+#define htole32(x) OSSwapHostToLittleInt32(x)
+#define be32toh(x) OSSwapBigToHostInt32(x)
+#define le32toh(x) OSSwapLittleToHostInt32(x)
+#define htobe64(x) OSSwapHostToBigInt64(x)
+#define htole64(x) OSSwapHostToLittleInt64(x)
+#define be64toh(x) OSSwapBigToHostInt64(x)
+#define le64toh(x) OSSwapLittleToHostInt64(x)
+#define __BYTE_ORDER    BYTE_ORDER
+#define __BIG_ENDIAN    BIG_ENDIAN
+#define __LITTLE_ENDIAN LITTLE_ENDIAN
+#define __PDP_ENDIAN    PDP_ENDIAN
+#endif
+
+#if defined(_WIN16) || defined(_WIN32) || defined(_WIN64) || defined(__WINDOWS__)
+#include <winsock2.h>
+#include <sys/param.h>
+#if BYTE_ORDER == LITTLE_ENDIAN
+#define htobe16(x) htons(x)
+#define htole16(x) (x)
+#define be16toh(x) ntohs(x)
+#define le16toh(x) (x)
+#define htobe32(x) htonl(x)
+#define htole32(x) (x)
+#define be32toh(x) ntohl(x)
+#define le32toh(x) (x)
+#define htobe64(x) htonll(x)
+#define htole64(x) (x)
+#define be64toh(x) ntohll(x)
+#define le64toh(x) (x)
+#elif BYTE_ORDER == BIG_ENDIAN
+#define htobe16(x) (x)
+#define htole16(x) __builtin_bswap16(x)
+#define be16toh(x) (x)
+#define le16toh(x) __builtin_bswap16(x)
+#define htobe32(x) (x)
+#define htole32(x) __builtin_bswap32(x)
+#define be32toh(x) (x)
+#define le32toh(x) __builtin_bswap32(x)
+#define htobe64(x) (x)
+#define htole64(x) __builtin_bswap64(x)
+#define be64toh(x) (x)
+#define le64toh(x) __builtin_bswap64(x)
+#else
+#error "byte order not supported"
+#endif
+#define __BYTE_ORDER    BYTE_ORDER
+#define __BIG_ENDIAN    BIG_ENDIAN
+#define __LITTLE_ENDIAN LITTLE_ENDIAN
+#define __PDP_ENDIAN    PDP_ENDIAN
+#endif
+
+#endif

--- a/src/network.c
+++ b/src/network.c
@@ -42,19 +42,9 @@
 #include "endpoint.h"
 #include "tcpstate.h"
 #include "tcpreasm.h"
+#include "endian_compat.h"
 
 #include <ldns/ldns.h>
-#ifdef HAVE_ENDIAN_H
-#include <endian.h>
-#else
-#ifdef HAVE_SYS_ENDIAN_H
-#include <sys/endian.h>
-#else
-#ifdef HAVE_MACHINE_ENDIAN_H
-#include <machine/endian.h>
-#endif
-#endif
-#endif
 
 struct ip6_hdr* network_ipv6 = 0;
 struct ip*      network_ip   = 0;


### PR DESCRIPTION
- Fix #241:
  - Add macros for Apple and Windows endian functions
  - `plugins/txtout`: Fix return check of `ldns_wire2pkt()`