### PR TITLE
v6bug

### DIFF
--- a/src/args.c
+++ b/src/args.c
@@ -182,7 +182,7 @@ void help_2(void)
         "             times to increase debugging\n"
         "  -1         flush output on every packet\n"
         "  -g         dump packets dig-style on stderr\n"
-        "  -6         compensate for PCAP/BPF IPv6 bug\n"
+        "  -6         (deprecated) compensate for PCAP/BPF IPv6 bug\n"
         "  -f         include fragmented packets\n"
         "  -T         include TCP packets (DNS header filters will inspect only the\n"
         "             first DNS header, and the result will apply to all messages\n"

--- a/src/bpft.c
+++ b/src/bpft.c
@@ -98,8 +98,8 @@ void prepare_bpft(void)
         /* tcp packets can be filtered by initiators/responders, but
          * not mbs/mbc. */
     }
-    len += text_add(&bpfl, " ( udp port %d", dns_port);
-    if (!v6bug) {
+    len += text_add(&bpfl, " ( udp port %d and ( ip6 or ( ip", dns_port);
+    // if (!v6bug) {
         if (udp10_mbc != 0)
             len += text_add(&bpfl, " and udp[10] & 0x%x = 0",
                 udp10_mbc);
@@ -122,8 +122,8 @@ void prepare_bpft(void)
             }
             len += text_add(&bpfl, " 0x%x << (udp[11] & 0xf) & 0x%x != 0 )", ERR_RCODE_BASE, err_wanted);
         }
-    }
-    len += text_add(&bpfl, " )"); /*  ... udp 53 ) */
+    // }
+    len += text_add(&bpfl, " )))"); /*  ... udp 53 ) */
     len += text_add(&bpfl, " )"); /*  ... ports ) */
     if (options.bpf_hosts_apply_all) {
         len += text_add(&bpfl, " )"); /*  ... dns ) */

--- a/src/dnscap.1.in
+++ b/src/dnscap.1.in
@@ -101,9 +101,10 @@ messages which passed through all of the filters.  If
 is also used, then every message will be dumped in both binary and
 presentation form.
 .It Fl 6
-Suppress the use of packet filter patterns that are known (as of 2007) to
-cause problems when processing IPv6 packets.  Recommended when IPv6 traffic is
-expected to be present.
+Used to suppress the use of packet filter patterns that cause problems when
+processing IPv6 packets.
+As of version 2.0.0 this option is deprecated and filters have been reworked
+to only match IPv4 packets, IPv6 filtering are processed at a higher level.
 .It Fl f
 Selects fragments (which could include unrelated flows since fragments do not
 contain port numbers), and includes fragments in the binary output.  Necessary


### PR DESCRIPTION
- Deprecate `-6` option by reworking the filter, which did not work on IPv6, to only run on IPv4