### PR TITLE
QTYPE match, args, tests

### DIFF
--- a/src/bpft.c
+++ b/src/bpft.c
@@ -100,28 +100,28 @@ void prepare_bpft(void)
     }
     len += text_add(&bpfl, " ( udp port %d and ( ip6 or ( ip", dns_port);
     // if (!v6bug) {
-        if (udp10_mbc != 0)
-            len += text_add(&bpfl, " and udp[10] & 0x%x = 0",
-                udp10_mbc);
-        if (udp10_mbs != 0)
-            len += text_add(&bpfl, " and udp[10] & 0x%x = 0x%x",
-                udp10_mbs, udp10_mbs);
-        if (udp11_mbc != 0)
-            len += text_add(&bpfl, " and udp[11] & 0x%x = 0",
-                udp11_mbc);
-        /* Dead code, udp11_mbs never set
+    if (udp10_mbc != 0)
+        len += text_add(&bpfl, " and udp[10] & 0x%x = 0",
+            udp10_mbc);
+    if (udp10_mbs != 0)
+        len += text_add(&bpfl, " and udp[10] & 0x%x = 0x%x",
+            udp10_mbs, udp10_mbs);
+    if (udp11_mbc != 0)
+        len += text_add(&bpfl, " and udp[11] & 0x%x = 0",
+            udp11_mbc);
+    /* Dead code, udp11_mbs never set
         if (udp11_mbs != 0)
             len += text_add(&bpfl, " and udp[11] & 0x%x = 0x%x",
                     udp11_mbs, udp11_mbs);
 */
 
-        if (err_wanted != ERR_NO) {
-            len += text_add(&bpfl, " and (");
-            if ((err_wanted & ERR_TRUNC) != 0) {
-                len += text_add(&bpfl, " udp[10] & 0x%x = 0x%x or", UDP10_TC_MASK, UDP10_TC_MASK);
-            }
-            len += text_add(&bpfl, " 0x%x << (udp[11] & 0xf) & 0x%x != 0 )", ERR_RCODE_BASE, err_wanted);
+    if (err_wanted != ERR_NO) {
+        len += text_add(&bpfl, " and (");
+        if ((err_wanted & ERR_TRUNC) != 0) {
+            len += text_add(&bpfl, " udp[10] & 0x%x = 0x%x or", UDP10_TC_MASK, UDP10_TC_MASK);
         }
+        len += text_add(&bpfl, " 0x%x << (udp[11] & 0xf) & 0x%x != 0 )", ERR_RCODE_BASE, err_wanted);
+    }
     // }
     len += text_add(&bpfl, " )))"); /*  ... udp 53 ) */
     len += text_add(&bpfl, " )"); /*  ... ports ) */

--- a/src/dnscap.1.in
+++ b/src/dnscap.1.in
@@ -48,6 +48,8 @@
 .Op Fl B Ar datetime
 .Op Fl E Ar datetime
 .Op Fl U Ar str
+.Op Fl q Ar num|str
+.Op Fl Q Ar num|str
 .Op Fl P Ar plugin.so ...
 .Sh DESCRIPTION
 .Nm
@@ -359,6 +361,14 @@ Enable immediate mode on interfaces.
 Append "and
 .Ar str
 " to the pcap filter.
+.It Fl q Ar num|str
+Only select DNS messages where QTYPE matches the specified type.
+Can not be used together with
+.Fl Q .
+.It Fl Q Ar num|str
+Only select DNS messages where QTYPE does not matches the specified type.
+Can not be used together with
+.Fl q .
 .It Fl P Ar plugin.so ...
 Load and use the specified plugin. Any options given after this are
 sent to the plugin.

--- a/src/dnscap.c
+++ b/src/dnscap.c
@@ -120,6 +120,8 @@ int                only_offline_pcaps   = FALSE;
 int                dont_drop_privileges = FALSE;
 options_t          options              = OPTIONS_T_DEFAULTS;
 
+ldns_rr_type match_qtype = 0, nmatch_qtype = 0;
+
 int main(int argc, char* argv[])
 {
     struct plugin* p;

--- a/src/dnscap.h
+++ b/src/dnscap.h
@@ -140,6 +140,8 @@
 #include <zlib.h>
 #endif
 
+#include <ldns/ldns.h>
+
 #ifndef IPV6_VERSION
 #define IPV6_VERSION 0x60
 #endif
@@ -434,5 +436,7 @@ extern pcap_thread_t      pcap_thread;
 extern int                only_offline_pcaps;
 extern int                dont_drop_privileges;
 extern options_t          options;
+
+extern ldns_rr_type match_qtype, nmatch_qtype;
 
 #endif /* __dnscap_dnscap_h */

--- a/src/endian_compat.h
+++ b/src/endian_compat.h
@@ -61,10 +61,10 @@
 #define htole64(x) OSSwapHostToLittleInt64(x)
 #define be64toh(x) OSSwapBigToHostInt64(x)
 #define le64toh(x) OSSwapLittleToHostInt64(x)
-#define __BYTE_ORDER    BYTE_ORDER
-#define __BIG_ENDIAN    BIG_ENDIAN
+#define __BYTE_ORDER BYTE_ORDER
+#define __BIG_ENDIAN BIG_ENDIAN
 #define __LITTLE_ENDIAN LITTLE_ENDIAN
-#define __PDP_ENDIAN    PDP_ENDIAN
+#define __PDP_ENDIAN PDP_ENDIAN
 #endif
 
 #if defined(_WIN16) || defined(_WIN32) || defined(_WIN64) || defined(__WINDOWS__)
@@ -99,10 +99,10 @@
 #else
 #error "byte order not supported"
 #endif
-#define __BYTE_ORDER    BYTE_ORDER
-#define __BIG_ENDIAN    BIG_ENDIAN
+#define __BYTE_ORDER BYTE_ORDER
+#define __BIG_ENDIAN BIG_ENDIAN
 #define __LITTLE_ENDIAN LITTLE_ENDIAN
-#define __PDP_ENDIAN    PDP_ENDIAN
+#define __PDP_ENDIAN PDP_ENDIAN
 #endif
 
 #endif

--- a/src/test/Makefile.am
+++ b/src/test/Makefile.am
@@ -14,10 +14,11 @@ CLEANFILES = test*.log test*.trs \
   test10.out \
   test11.out \
   test12.out test12.20161020.152301.075993.gz \
-  test13.out
+  test13.out \
+  test14.out
 
 TESTS = test1.sh test2.sh test3.sh test4.sh test5.sh test6.sh test7.sh \
-  test8.sh test9.sh test10.sh test11.sh test12.sh test13.sh
+  test8.sh test9.sh test10.sh test11.sh test12.sh test13.sh test14.sh
 
 test1.sh: dns.pcap-dist
 
@@ -47,6 +48,8 @@ test12.sh: dns.pcap-dist
 
 test13.sh: dns.pcap-dist
 
+test14.sh: dns.pcap-dist
+
 .pcap.pcap-dist:
 	cp "$<" "$@"
 
@@ -61,4 +64,5 @@ EXTRA_DIST = $(TESTS) \
   test8.gold dnsotcp-many1pkt.pcap dnsotcp-manyopkts.pcap \
   dnso1tcp-bighole.pcap \
   test9.gold \
-  dns6.pcap test10.gold
+  dns6.pcap test10.gold \
+  test14.gold

--- a/src/test/test1.sh
+++ b/src/test/test1.sh
@@ -2,13 +2,6 @@
 
 ../dnscap -g -r dns.pcap-dist 2>dns.out
 
-osrel=`uname -s`
-if [ "$osrel" = "OpenBSD" ]; then
-    mv dns.out dns.out.old
-    grep -v "^dnscap.*WARNING.*symbol.*relink" dns.out.old > dns.out
-    rm dns.out.old
-fi
-
 mv dns.out dns.out.old
 grep -v "^libgcov profiling error:" dns.out.old > dns.out
 rm dns.out.old

--- a/src/test/test10.sh
+++ b/src/test/test10.sh
@@ -3,19 +3,4 @@
 ../dnscap -r dns6.pcap-dist -6 -g 2>test10.out
 ../dnscap -r dns6.pcap-dist -6 -o use_layers=yes -g 2>>test10.out
 
-osrel=`uname -s`
-if [ "$osrel" = "OpenBSD" ]; then
-    mv test10.out test10.out.old
-    grep -v "^dnscap.*WARNING.*symbol.*relink" test10.out.old > test10.out
-    rm test10.out.old
-fi
-
-# TODO: Remove when #133 is fixed
-cat test10.out | \
-  sed 's%,CLASS4096,OPT,%,4096,4096,%' | \
-  sed 's%,CLASS512,OPT,%,512,512,%' | \
-  sed 's%,41,41,0,edns0\[len=0,UDP=4096,%,4096,4096,0,edns0[len=0,UDP=4096,%' | \
-  sed 's%,41,41,0,edns0\[len=0,UDP=512,%,512,512,0,edns0[len=0,UDP=512,%' >test10.new
-mv test10.new test10.out
-
 diff test10.out "$srcdir/test10.gold"

--- a/src/test/test14.gold
+++ b/src/test/test14.gold
@@ -1,0 +1,2864 @@
+-- only 1
+[56] 2016-10-20 15:23:01.075993 [#0 dns.pcap-dist 4095] \
+	[172.17.0.10].53199 [8.8.8.8].53  \
+	dns QUERY,NOERROR,59311,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:23:01.077982 [#1 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].53199  \
+	dns QUERY,NOERROR,59311,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,44,216.58.218.206 \
+	4 google.com,IN,NS,157880,ns4.google.com \
+	google.com,IN,NS,157880,ns3.google.com \
+	google.com,IN,NS,157880,ns1.google.com \
+	google.com,IN,NS,157880,ns2.google.com \
+	4 ns2.google.com,IN,A,157880,216.239.34.10 \
+	ns1.google.com,IN,A,331882,216.239.32.10 \
+	ns3.google.com,IN,A,157880,216.239.36.10 \
+	ns4.google.com,IN,A,157880,216.239.38.10
+[56] 2016-10-20 15:23:01.087291 [#2 dns.pcap-dist 4095] \
+	[172.17.0.10].40043 [8.8.8.8].53  \
+	dns QUERY,NOERROR,5337,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:23:01.088733 [#3 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].40043  \
+	dns QUERY,NOERROR,5337,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,44,216.58.218.206 \
+	4 google.com,IN,NS,157880,ns1.google.com \
+	google.com,IN,NS,157880,ns2.google.com \
+	google.com,IN,NS,157880,ns3.google.com \
+	google.com,IN,NS,157880,ns4.google.com \
+	4 ns2.google.com,IN,A,157880,216.239.34.10 \
+	ns1.google.com,IN,A,331882,216.239.32.10 \
+	ns3.google.com,IN,A,157880,216.239.36.10 \
+	ns4.google.com,IN,A,157880,216.239.38.10
+[56] 2016-10-20 15:23:10.322117 [#4 dns.pcap-dist 4095] \
+	[172.17.0.10].37953 [8.8.8.8].53  \
+	dns QUERY,NOERROR,22982,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:23:10.323399 [#5 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].37953  \
+	dns QUERY,NOERROR,22982,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,34,216.58.218.206 \
+	4 google.com,IN,NS,157870,ns4.google.com \
+	google.com,IN,NS,157870,ns1.google.com \
+	google.com,IN,NS,157870,ns2.google.com \
+	google.com,IN,NS,157870,ns3.google.com \
+	4 ns2.google.com,IN,A,157870,216.239.34.10 \
+	ns1.google.com,IN,A,331872,216.239.32.10 \
+	ns3.google.com,IN,A,157870,216.239.36.10 \
+	ns4.google.com,IN,A,157870,216.239.38.10
+[56] 2016-10-20 15:23:52.860937 [#6 dns.pcap-dist 4095] \
+	[172.17.0.10].40953 [8.8.8.8].53  \
+	dns QUERY,NOERROR,22531,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:23:52.863771 [#7 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].40953  \
+	dns QUERY,NOERROR,22531,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,297,216.58.218.206 \
+	4 google.com,IN,NS,157828,ns2.google.com \
+	google.com,IN,NS,157828,ns4.google.com \
+	google.com,IN,NS,157828,ns1.google.com \
+	google.com,IN,NS,157828,ns3.google.com \
+	4 ns2.google.com,IN,A,157828,216.239.34.10 \
+	ns1.google.com,IN,A,331830,216.239.32.10 \
+	ns3.google.com,IN,A,157828,216.239.36.10 \
+	ns4.google.com,IN,A,157828,216.239.38.10
+[56] 2016-10-20 15:23:59.083869 [#8 dns.pcap-dist 4095] \
+	[172.17.0.10].45174 [8.8.8.8].53  \
+	dns QUERY,NOERROR,58510,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:23:59.086104 [#9 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].45174  \
+	dns QUERY,NOERROR,58510,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,291,216.58.218.206 \
+	4 google.com,IN,NS,157822,ns2.google.com \
+	google.com,IN,NS,157822,ns3.google.com \
+	google.com,IN,NS,157822,ns1.google.com \
+	google.com,IN,NS,157822,ns4.google.com \
+	4 ns2.google.com,IN,A,157822,216.239.34.10 \
+	ns1.google.com,IN,A,331824,216.239.32.10 \
+	ns3.google.com,IN,A,157822,216.239.36.10 \
+	ns4.google.com,IN,A,157822,216.239.38.10
+[56] 2016-10-20 15:24:04.323868 [#10 dns.pcap-dist 4095] \
+	[172.17.0.10].43559 [8.8.8.8].53  \
+	dns QUERY,NOERROR,49483,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:04.325597 [#11 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].43559  \
+	dns QUERY,NOERROR,49483,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,285,216.58.218.206 \
+	4 google.com,IN,NS,157816,ns4.google.com \
+	google.com,IN,NS,157816,ns3.google.com \
+	google.com,IN,NS,157816,ns1.google.com \
+	google.com,IN,NS,157816,ns2.google.com \
+	4 ns2.google.com,IN,A,157816,216.239.34.10 \
+	ns1.google.com,IN,A,331818,216.239.32.10 \
+	ns3.google.com,IN,A,157816,216.239.36.10 \
+	ns4.google.com,IN,A,157816,216.239.38.10
+[56] 2016-10-20 15:24:06.332239 [#12 dns.pcap-dist 4095] \
+	[172.17.0.10].54859 [8.8.8.8].53  \
+	dns QUERY,NOERROR,31669,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:06.333743 [#13 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].54859  \
+	dns QUERY,NOERROR,31669,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,283,216.58.218.206 \
+	4 google.com,IN,NS,157814,ns2.google.com \
+	google.com,IN,NS,157814,ns1.google.com \
+	google.com,IN,NS,157814,ns4.google.com \
+	google.com,IN,NS,157814,ns3.google.com \
+	4 ns2.google.com,IN,A,157814,216.239.34.10 \
+	ns1.google.com,IN,A,331816,216.239.32.10 \
+	ns3.google.com,IN,A,157814,216.239.36.10 \
+	ns4.google.com,IN,A,157814,216.239.38.10
+[56] 2016-10-20 15:24:07.346429 [#14 dns.pcap-dist 4095] \
+	[172.17.0.10].41266 [8.8.8.8].53  \
+	dns QUERY,NOERROR,63798,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:07.348160 [#15 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].41266  \
+	dns QUERY,NOERROR,63798,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,282,216.58.218.206 \
+	4 google.com,IN,NS,157813,ns4.google.com \
+	google.com,IN,NS,157813,ns1.google.com \
+	google.com,IN,NS,157813,ns3.google.com \
+	google.com,IN,NS,157813,ns2.google.com \
+	4 ns2.google.com,IN,A,157813,216.239.34.10 \
+	ns1.google.com,IN,A,331815,216.239.32.10 \
+	ns3.google.com,IN,A,157813,216.239.36.10 \
+	ns4.google.com,IN,A,157813,216.239.38.10
+[56] 2016-10-20 15:24:08.360528 [#16 dns.pcap-dist 4095] \
+	[172.17.0.10].60437 [8.8.8.8].53  \
+	dns QUERY,NOERROR,60258,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:08.362206 [#17 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].60437  \
+	dns QUERY,NOERROR,60258,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,281,216.58.218.206 \
+	4 google.com,IN,NS,157812,ns3.google.com \
+	google.com,IN,NS,157812,ns2.google.com \
+	google.com,IN,NS,157812,ns4.google.com \
+	google.com,IN,NS,157812,ns1.google.com \
+	4 ns2.google.com,IN,A,157812,216.239.34.10 \
+	ns1.google.com,IN,A,331814,216.239.32.10 \
+	ns3.google.com,IN,A,157812,216.239.36.10 \
+	ns4.google.com,IN,A,157812,216.239.38.10
+[56] 2016-10-20 15:24:09.375942 [#18 dns.pcap-dist 4095] \
+	[172.17.0.10].53820 [8.8.8.8].53  \
+	dns QUERY,NOERROR,45512,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:09.378425 [#19 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].53820  \
+	dns QUERY,NOERROR,45512,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,280,216.58.218.206 \
+	4 google.com,IN,NS,157811,ns3.google.com \
+	google.com,IN,NS,157811,ns4.google.com \
+	google.com,IN,NS,157811,ns1.google.com \
+	google.com,IN,NS,157811,ns2.google.com \
+	4 ns2.google.com,IN,A,157811,216.239.34.10 \
+	ns1.google.com,IN,A,331813,216.239.32.10 \
+	ns3.google.com,IN,A,157811,216.239.36.10 \
+	ns4.google.com,IN,A,157811,216.239.38.10
+[56] 2016-10-20 15:24:10.391358 [#20 dns.pcap-dist 4095] \
+	[172.17.0.10].47637 [8.8.8.8].53  \
+	dns QUERY,NOERROR,1834,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:10.392886 [#21 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].47637  \
+	dns QUERY,NOERROR,1834,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,279,216.58.218.206 \
+	4 google.com,IN,NS,157810,ns1.google.com \
+	google.com,IN,NS,157810,ns2.google.com \
+	google.com,IN,NS,157810,ns4.google.com \
+	google.com,IN,NS,157810,ns3.google.com \
+	4 ns2.google.com,IN,A,157810,216.239.34.10 \
+	ns1.google.com,IN,A,331812,216.239.32.10 \
+	ns3.google.com,IN,A,157810,216.239.36.10 \
+	ns4.google.com,IN,A,157810,216.239.38.10
+[56] 2016-10-20 15:24:11.406297 [#22 dns.pcap-dist 4095] \
+	[172.17.0.10].41059 [8.8.8.8].53  \
+	dns QUERY,NOERROR,48432,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:11.407460 [#23 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].41059  \
+	dns QUERY,NOERROR,48432,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,278,216.58.218.206 \
+	4 google.com,IN,NS,157809,ns3.google.com \
+	google.com,IN,NS,157809,ns4.google.com \
+	google.com,IN,NS,157809,ns2.google.com \
+	google.com,IN,NS,157809,ns1.google.com \
+	4 ns2.google.com,IN,A,157809,216.239.34.10 \
+	ns1.google.com,IN,A,331811,216.239.32.10 \
+	ns3.google.com,IN,A,157809,216.239.36.10 \
+	ns4.google.com,IN,A,157809,216.239.38.10
+[56] 2016-10-20 15:24:12.419936 [#24 dns.pcap-dist 4095] \
+	[172.17.0.10].32976 [8.8.8.8].53  \
+	dns QUERY,NOERROR,12038,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:12.421228 [#25 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].32976  \
+	dns QUERY,NOERROR,12038,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,277,216.58.218.206 \
+	4 google.com,IN,NS,157808,ns2.google.com \
+	google.com,IN,NS,157808,ns3.google.com \
+	google.com,IN,NS,157808,ns1.google.com \
+	google.com,IN,NS,157808,ns4.google.com \
+	4 ns2.google.com,IN,A,157808,216.239.34.10 \
+	ns1.google.com,IN,A,331810,216.239.32.10 \
+	ns3.google.com,IN,A,157808,216.239.36.10 \
+	ns4.google.com,IN,A,157808,216.239.38.10
+[56] 2016-10-20 15:24:14.428524 [#26 dns.pcap-dist 4095] \
+	[172.17.0.10].53467 [8.8.8.8].53  \
+	dns QUERY,NOERROR,11614,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:14.429863 [#27 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].53467  \
+	dns QUERY,NOERROR,11614,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,275,216.58.218.206 \
+	4 google.com,IN,NS,157806,ns3.google.com \
+	google.com,IN,NS,157806,ns1.google.com \
+	google.com,IN,NS,157806,ns4.google.com \
+	google.com,IN,NS,157806,ns2.google.com \
+	4 ns2.google.com,IN,A,157806,216.239.34.10 \
+	ns1.google.com,IN,A,331808,216.239.32.10 \
+	ns3.google.com,IN,A,157806,216.239.36.10 \
+	ns4.google.com,IN,A,157806,216.239.38.10
+[56] 2016-10-20 15:24:16.435733 [#28 dns.pcap-dist 4095] \
+	[172.17.0.10].41532 [8.8.8.8].53  \
+	dns QUERY,NOERROR,59173,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:16.437471 [#29 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].41532  \
+	dns QUERY,NOERROR,59173,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,273,216.58.218.206 \
+	4 google.com,IN,NS,157804,ns1.google.com \
+	google.com,IN,NS,157804,ns3.google.com \
+	google.com,IN,NS,157804,ns2.google.com \
+	google.com,IN,NS,157804,ns4.google.com \
+	4 ns2.google.com,IN,A,157804,216.239.34.10 \
+	ns1.google.com,IN,A,331806,216.239.32.10 \
+	ns3.google.com,IN,A,157804,216.239.36.10 \
+	ns4.google.com,IN,A,157804,216.239.38.10
+[56] 2016-10-20 15:24:18.445519 [#30 dns.pcap-dist 4095] \
+	[172.17.0.10].44982 [8.8.8.8].53  \
+	dns QUERY,NOERROR,45535,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:18.446775 [#31 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].44982  \
+	dns QUERY,NOERROR,45535,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,271,216.58.218.206 \
+	4 google.com,IN,NS,157802,ns4.google.com \
+	google.com,IN,NS,157802,ns2.google.com \
+	google.com,IN,NS,157802,ns1.google.com \
+	google.com,IN,NS,157802,ns3.google.com \
+	4 ns2.google.com,IN,A,157802,216.239.34.10 \
+	ns1.google.com,IN,A,331804,216.239.32.10 \
+	ns3.google.com,IN,A,157802,216.239.36.10 \
+	ns4.google.com,IN,A,157802,216.239.38.10
+[56] 2016-10-20 15:24:19.460087 [#32 dns.pcap-dist 4095] \
+	[172.17.0.10].45658 [8.8.8.8].53  \
+	dns QUERY,NOERROR,64325,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:19.462224 [#33 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].45658  \
+	dns QUERY,NOERROR,64325,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,270,216.58.218.206 \
+	4 google.com,IN,NS,157801,ns1.google.com \
+	google.com,IN,NS,157801,ns3.google.com \
+	google.com,IN,NS,157801,ns4.google.com \
+	google.com,IN,NS,157801,ns2.google.com \
+	4 ns2.google.com,IN,A,157801,216.239.34.10 \
+	ns1.google.com,IN,A,331803,216.239.32.10 \
+	ns3.google.com,IN,A,157801,216.239.36.10 \
+	ns4.google.com,IN,A,157801,216.239.38.10
+[56] 2016-10-20 15:24:20.475086 [#34 dns.pcap-dist 4095] \
+	[172.17.0.10].59762 [8.8.8.8].53  \
+	dns QUERY,NOERROR,20736,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:20.476841 [#35 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].59762  \
+	dns QUERY,NOERROR,20736,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,269,216.58.218.206 \
+	4 google.com,IN,NS,157800,ns3.google.com \
+	google.com,IN,NS,157800,ns1.google.com \
+	google.com,IN,NS,157800,ns4.google.com \
+	google.com,IN,NS,157800,ns2.google.com \
+	4 ns2.google.com,IN,A,157800,216.239.34.10 \
+	ns1.google.com,IN,A,331802,216.239.32.10 \
+	ns3.google.com,IN,A,157800,216.239.36.10 \
+	ns4.google.com,IN,A,157800,216.239.38.10
+[56] 2016-10-20 15:24:21.489468 [#36 dns.pcap-dist 4095] \
+	[172.17.0.10].37669 [8.8.8.8].53  \
+	dns QUERY,NOERROR,64358,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:21.490573 [#37 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].37669  \
+	dns QUERY,NOERROR,64358,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,268,216.58.218.206 \
+	4 google.com,IN,NS,157799,ns2.google.com \
+	google.com,IN,NS,157799,ns1.google.com \
+	google.com,IN,NS,157799,ns4.google.com \
+	google.com,IN,NS,157799,ns3.google.com \
+	4 ns2.google.com,IN,A,157799,216.239.34.10 \
+	ns1.google.com,IN,A,331801,216.239.32.10 \
+	ns3.google.com,IN,A,157799,216.239.36.10 \
+	ns4.google.com,IN,A,157799,216.239.38.10
+[56] 2016-10-20 15:24:22.502667 [#38 dns.pcap-dist 4095] \
+	[172.17.0.10].49829 [8.8.8.8].53  \
+	dns QUERY,NOERROR,54706,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:22.504738 [#39 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].49829  \
+	dns QUERY,NOERROR,54706,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,267,216.58.218.206 \
+	4 google.com,IN,NS,157798,ns2.google.com \
+	google.com,IN,NS,157798,ns4.google.com \
+	google.com,IN,NS,157798,ns3.google.com \
+	google.com,IN,NS,157798,ns1.google.com \
+	4 ns2.google.com,IN,A,157798,216.239.34.10 \
+	ns1.google.com,IN,A,331800,216.239.32.10 \
+	ns3.google.com,IN,A,157798,216.239.36.10 \
+	ns4.google.com,IN,A,157798,216.239.38.10
+[56] 2016-10-20 15:24:23.520203 [#40 dns.pcap-dist 4095] \
+	[172.17.0.10].44980 [8.8.8.8].53  \
+	dns QUERY,NOERROR,41808,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:23.521976 [#41 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].44980  \
+	dns QUERY,NOERROR,41808,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,266,216.58.218.206 \
+	4 google.com,IN,NS,157797,ns2.google.com \
+	google.com,IN,NS,157797,ns4.google.com \
+	google.com,IN,NS,157797,ns1.google.com \
+	google.com,IN,NS,157797,ns3.google.com \
+	4 ns2.google.com,IN,A,157797,216.239.34.10 \
+	ns1.google.com,IN,A,331799,216.239.32.10 \
+	ns3.google.com,IN,A,157797,216.239.36.10 \
+	ns4.google.com,IN,A,157797,216.239.38.10
+[56] 2016-10-20 15:24:24.537264 [#42 dns.pcap-dist 4095] \
+	[172.17.0.10].42042 [8.8.8.8].53  \
+	dns QUERY,NOERROR,10624,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:24.539398 [#43 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].42042  \
+	dns QUERY,NOERROR,10624,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,265,216.58.218.206 \
+	4 google.com,IN,NS,157796,ns3.google.com \
+	google.com,IN,NS,157796,ns4.google.com \
+	google.com,IN,NS,157796,ns1.google.com \
+	google.com,IN,NS,157796,ns2.google.com \
+	4 ns2.google.com,IN,A,157796,216.239.34.10 \
+	ns1.google.com,IN,A,331798,216.239.32.10 \
+	ns3.google.com,IN,A,157796,216.239.36.10 \
+	ns4.google.com,IN,A,157796,216.239.38.10
+[56] 2016-10-20 15:24:25.554744 [#44 dns.pcap-dist 4095] \
+	[172.17.0.10].45703 [8.8.8.8].53  \
+	dns QUERY,NOERROR,61415,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:25.556513 [#45 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].45703  \
+	dns QUERY,NOERROR,61415,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,264,216.58.218.206 \
+	4 google.com,IN,NS,157795,ns3.google.com \
+	google.com,IN,NS,157795,ns4.google.com \
+	google.com,IN,NS,157795,ns2.google.com \
+	google.com,IN,NS,157795,ns1.google.com \
+	4 ns2.google.com,IN,A,157795,216.239.34.10 \
+	ns1.google.com,IN,A,331797,216.239.32.10 \
+	ns3.google.com,IN,A,157795,216.239.36.10 \
+	ns4.google.com,IN,A,157795,216.239.38.10
+[56] 2016-10-20 15:24:26.572784 [#46 dns.pcap-dist 4095] \
+	[172.17.0.10].46798 [8.8.8.8].53  \
+	dns QUERY,NOERROR,17700,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:26.574350 [#47 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].46798  \
+	dns QUERY,NOERROR,17700,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,263,216.58.218.206 \
+	4 google.com,IN,NS,157794,ns1.google.com \
+	google.com,IN,NS,157794,ns4.google.com \
+	google.com,IN,NS,157794,ns3.google.com \
+	google.com,IN,NS,157794,ns2.google.com \
+	4 ns2.google.com,IN,A,157794,216.239.34.10 \
+	ns1.google.com,IN,A,331796,216.239.32.10 \
+	ns3.google.com,IN,A,157794,216.239.36.10 \
+	ns4.google.com,IN,A,157794,216.239.38.10
+-- not 1
+[73] 2016-10-20 15:23:01.082865 [#0 dns.pcap-dist 4095] \
+	[172.17.0.10].57822 [8.8.8.8].53  \
+	dns QUERY,NOERROR,35665,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:23:01.084107 [#1 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].57822  \
+	dns QUERY,NOERROR,35665,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72125,dfw06s47-in-f14.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72125,dfw06s47-in-f206.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71608,ns2.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71608,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71608,ns1.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71608,ns4.google.com \
+	4 ns1.google.com,IN,A,331882,216.239.32.10 \
+	ns3.google.com,IN,A,157880,216.239.36.10 \
+	ns4.google.com,IN,A,157880,216.239.38.10 \
+	ns2.google.com,IN,A,157880,216.239.34.10
+[73] 2016-10-20 15:23:10.328324 [#2 dns.pcap-dist 4095] \
+	[172.17.0.10].48658 [8.8.8.8].53  \
+	dns QUERY,NOERROR,18718,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:23:10.329572 [#3 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].48658  \
+	dns QUERY,NOERROR,18718,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72115,dfw06s47-in-f206.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72115,dfw06s47-in-f14.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71598,ns2.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71598,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71598,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71598,ns1.google.com \
+	4 ns1.google.com,IN,A,331872,216.239.32.10 \
+	ns3.google.com,IN,A,157870,216.239.36.10 \
+	ns4.google.com,IN,A,157870,216.239.38.10 \
+	ns2.google.com,IN,A,157870,216.239.34.10
+[73] 2016-10-20 15:23:59.090911 [#4 dns.pcap-dist 4095] \
+	[172.17.0.10].33916 [8.8.8.8].53  \
+	dns QUERY,NOERROR,45248,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:23:59.092204 [#5 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].33916  \
+	dns QUERY,NOERROR,45248,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72067,dfw06s47-in-f14.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72067,dfw06s47-in-f206.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71550,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71550,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71550,ns2.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71550,ns1.google.com \
+	4 ns1.google.com,IN,A,331824,216.239.32.10 \
+	ns3.google.com,IN,A,157822,216.239.36.10 \
+	ns4.google.com,IN,A,157822,216.239.38.10 \
+	ns2.google.com,IN,A,157822,216.239.34.10
+[73] 2016-10-20 15:24:06.339145 [#6 dns.pcap-dist 4095] \
+	[172.17.0.10].58176 [8.8.8.8].53  \
+	dns QUERY,NOERROR,25433,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:06.340820 [#7 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].58176  \
+	dns QUERY,NOERROR,25433,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72059,dfw06s47-in-f206.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72059,dfw06s47-in-f14.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71542,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71542,ns1.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71542,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71542,ns2.google.com \
+	4 ns1.google.com,IN,A,331816,216.239.32.10 \
+	ns3.google.com,IN,A,157814,216.239.36.10 \
+	ns4.google.com,IN,A,157814,216.239.38.10 \
+	ns2.google.com,IN,A,157814,216.239.34.10
+[73] 2016-10-20 15:24:07.353123 [#8 dns.pcap-dist 4095] \
+	[172.17.0.10].34607 [8.8.8.8].53  \
+	dns QUERY,NOERROR,8470,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:07.354682 [#9 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].34607  \
+	dns QUERY,NOERROR,8470,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72058,dfw06s47-in-f14.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72058,dfw06s47-in-f206.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71541,ns1.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71541,ns2.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71541,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71541,ns3.google.com \
+	4 ns1.google.com,IN,A,331815,216.239.32.10 \
+	ns3.google.com,IN,A,157813,216.239.36.10 \
+	ns4.google.com,IN,A,157813,216.239.38.10 \
+	ns2.google.com,IN,A,157813,216.239.34.10
+[73] 2016-10-20 15:24:08.368516 [#10 dns.pcap-dist 4095] \
+	[172.17.0.10].37149 [8.8.8.8].53  \
+	dns QUERY,NOERROR,44985,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:08.370119 [#11 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].37149  \
+	dns QUERY,NOERROR,44985,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72057,dfw06s47-in-f206.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72057,dfw06s47-in-f14.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71540,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71540,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71540,ns1.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71540,ns2.google.com \
+	4 ns1.google.com,IN,A,331814,216.239.32.10 \
+	ns3.google.com,IN,A,157812,216.239.36.10 \
+	ns4.google.com,IN,A,157812,216.239.38.10 \
+	ns2.google.com,IN,A,157812,216.239.34.10
+[73] 2016-10-20 15:24:09.384057 [#12 dns.pcap-dist 4095] \
+	[172.17.0.10].52368 [8.8.8.8].53  \
+	dns QUERY,NOERROR,22980,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:09.385463 [#13 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].52368  \
+	dns QUERY,NOERROR,22980,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72056,dfw06s47-in-f14.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72056,dfw06s47-in-f206.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71539,ns2.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71539,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71539,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71539,ns1.google.com \
+	4 ns1.google.com,IN,A,331813,216.239.32.10 \
+	ns3.google.com,IN,A,157811,216.239.36.10 \
+	ns4.google.com,IN,A,157811,216.239.38.10 \
+	ns2.google.com,IN,A,157811,216.239.34.10
+[73] 2016-10-20 15:24:10.398099 [#14 dns.pcap-dist 4095] \
+	[172.17.0.10].34426 [8.8.8.8].53  \
+	dns QUERY,NOERROR,25431,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:10.400317 [#15 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].34426  \
+	dns QUERY,NOERROR,25431,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72055,dfw06s47-in-f206.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72055,dfw06s47-in-f14.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71538,ns1.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71538,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71538,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71538,ns2.google.com \
+	4 ns1.google.com,IN,A,331812,216.239.32.10 \
+	ns3.google.com,IN,A,157810,216.239.36.10 \
+	ns4.google.com,IN,A,157810,216.239.38.10 \
+	ns2.google.com,IN,A,157810,216.239.34.10
+[73] 2016-10-20 15:24:11.412133 [#16 dns.pcap-dist 4095] \
+	[172.17.0.10].51181 [8.8.8.8].53  \
+	dns QUERY,NOERROR,47411,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:11.413370 [#17 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].51181  \
+	dns QUERY,NOERROR,47411,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72054,dfw06s47-in-f14.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72054,dfw06s47-in-f206.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71537,ns2.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71537,ns1.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71537,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71537,ns4.google.com \
+	4 ns1.google.com,IN,A,331811,216.239.32.10 \
+	ns3.google.com,IN,A,157809,216.239.36.10 \
+	ns4.google.com,IN,A,157809,216.239.38.10 \
+	ns2.google.com,IN,A,157809,216.239.34.10
+[73] 2016-10-20 15:24:18.452451 [#18 dns.pcap-dist 4095] \
+	[172.17.0.10].40224 [8.8.8.8].53  \
+	dns QUERY,NOERROR,60808,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:18.454030 [#19 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].40224  \
+	dns QUERY,NOERROR,60808,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72047,dfw06s47-in-f206.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72047,dfw06s47-in-f14.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71530,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71530,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71530,ns2.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71530,ns1.google.com \
+	4 ns1.google.com,IN,A,331804,216.239.32.10 \
+	ns3.google.com,IN,A,157802,216.239.36.10 \
+	ns4.google.com,IN,A,157802,216.239.38.10 \
+	ns2.google.com,IN,A,157802,216.239.34.10
+[73] 2016-10-20 15:24:19.467324 [#20 dns.pcap-dist 4095] \
+	[172.17.0.10].60457 [8.8.8.8].53  \
+	dns QUERY,NOERROR,25543,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:19.468895 [#21 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].60457  \
+	dns QUERY,NOERROR,25543,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72046,dfw06s47-in-f14.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72046,dfw06s47-in-f206.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71529,ns2.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71529,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71529,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71529,ns1.google.com \
+	4 ns1.google.com,IN,A,331803,216.239.32.10 \
+	ns3.google.com,IN,A,157801,216.239.36.10 \
+	ns4.google.com,IN,A,157801,216.239.38.10 \
+	ns2.google.com,IN,A,157801,216.239.34.10
+[73] 2016-10-20 15:24:20.482188 [#22 dns.pcap-dist 4095] \
+	[172.17.0.10].56022 [8.8.8.8].53  \
+	dns QUERY,NOERROR,25911,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:20.483927 [#23 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].56022  \
+	dns QUERY,NOERROR,25911,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72045,dfw06s47-in-f206.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72045,dfw06s47-in-f14.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71528,ns1.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71528,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71528,ns2.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71528,ns3.google.com \
+	4 ns1.google.com,IN,A,331802,216.239.32.10 \
+	ns3.google.com,IN,A,157800,216.239.36.10 \
+	ns4.google.com,IN,A,157800,216.239.38.10 \
+	ns2.google.com,IN,A,157800,216.239.34.10
+[73] 2016-10-20 15:24:21.495324 [#24 dns.pcap-dist 4095] \
+	[172.17.0.10].42978 [8.8.8.8].53  \
+	dns QUERY,NOERROR,37698,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:21.496815 [#25 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].42978  \
+	dns QUERY,NOERROR,37698,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72044,dfw06s47-in-f14.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72044,dfw06s47-in-f206.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71527,ns1.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71527,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71527,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71527,ns2.google.com \
+	4 ns1.google.com,IN,A,331801,216.239.32.10 \
+	ns3.google.com,IN,A,157799,216.239.36.10 \
+	ns4.google.com,IN,A,157799,216.239.38.10 \
+	ns2.google.com,IN,A,157799,216.239.34.10
+[73] 2016-10-20 15:24:22.510176 [#26 dns.pcap-dist 4095] \
+	[172.17.0.10].50599 [8.8.8.8].53  \
+	dns QUERY,NOERROR,32142,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:22.511746 [#27 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].50599  \
+	dns QUERY,NOERROR,32142,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72043,dfw06s47-in-f206.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72043,dfw06s47-in-f14.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71526,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71526,ns1.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71526,ns2.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71526,ns4.google.com \
+	4 ns1.google.com,IN,A,331800,216.239.32.10 \
+	ns3.google.com,IN,A,157798,216.239.36.10 \
+	ns4.google.com,IN,A,157798,216.239.38.10 \
+	ns2.google.com,IN,A,157798,216.239.34.10
+[73] 2016-10-20 15:24:23.527449 [#28 dns.pcap-dist 4095] \
+	[172.17.0.10].60063 [8.8.8.8].53  \
+	dns QUERY,NOERROR,18886,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:23.529385 [#29 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].60063  \
+	dns QUERY,NOERROR,18886,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72042,dfw06s47-in-f14.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72042,dfw06s47-in-f206.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71525,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71525,ns1.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71525,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71525,ns2.google.com \
+	4 ns1.google.com,IN,A,331799,216.239.32.10 \
+	ns3.google.com,IN,A,157797,216.239.36.10 \
+	ns4.google.com,IN,A,157797,216.239.38.10 \
+	ns2.google.com,IN,A,157797,216.239.34.10
+[73] 2016-10-20 15:24:24.544538 [#30 dns.pcap-dist 4095] \
+	[172.17.0.10].60469 [8.8.8.8].53  \
+	dns QUERY,NOERROR,33139,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:24.546172 [#31 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].60469  \
+	dns QUERY,NOERROR,33139,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72041,dfw06s47-in-f206.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72041,dfw06s47-in-f14.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71524,ns2.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71524,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71524,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71524,ns1.google.com \
+	4 ns1.google.com,IN,A,331798,216.239.32.10 \
+	ns3.google.com,IN,A,157796,216.239.36.10 \
+	ns4.google.com,IN,A,157796,216.239.38.10 \
+	ns2.google.com,IN,A,157796,216.239.34.10
+[73] 2016-10-20 15:24:25.562608 [#32 dns.pcap-dist 4095] \
+	[172.17.0.10].33507 [8.8.8.8].53  \
+	dns QUERY,NOERROR,59258,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:25.564509 [#33 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].33507  \
+	dns QUERY,NOERROR,59258,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72040,dfw06s47-in-f14.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72040,dfw06s47-in-f206.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71523,ns1.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71523,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71523,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71523,ns2.google.com \
+	4 ns1.google.com,IN,A,331797,216.239.32.10 \
+	ns3.google.com,IN,A,157795,216.239.36.10 \
+	ns4.google.com,IN,A,157795,216.239.38.10 \
+	ns2.google.com,IN,A,157795,216.239.34.10
+-- only PTR
+[73] 2016-10-20 15:23:01.082865 [#0 dns.pcap-dist 4095] \
+	[172.17.0.10].57822 [8.8.8.8].53  \
+	dns QUERY,NOERROR,35665,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:23:01.084107 [#1 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].57822  \
+	dns QUERY,NOERROR,35665,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72125,dfw06s47-in-f14.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72125,dfw06s47-in-f206.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71608,ns2.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71608,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71608,ns1.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71608,ns4.google.com \
+	4 ns1.google.com,IN,A,331882,216.239.32.10 \
+	ns3.google.com,IN,A,157880,216.239.36.10 \
+	ns4.google.com,IN,A,157880,216.239.38.10 \
+	ns2.google.com,IN,A,157880,216.239.34.10
+[73] 2016-10-20 15:23:10.328324 [#2 dns.pcap-dist 4095] \
+	[172.17.0.10].48658 [8.8.8.8].53  \
+	dns QUERY,NOERROR,18718,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:23:10.329572 [#3 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].48658  \
+	dns QUERY,NOERROR,18718,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72115,dfw06s47-in-f206.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72115,dfw06s47-in-f14.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71598,ns2.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71598,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71598,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71598,ns1.google.com \
+	4 ns1.google.com,IN,A,331872,216.239.32.10 \
+	ns3.google.com,IN,A,157870,216.239.36.10 \
+	ns4.google.com,IN,A,157870,216.239.38.10 \
+	ns2.google.com,IN,A,157870,216.239.34.10
+[73] 2016-10-20 15:23:59.090911 [#4 dns.pcap-dist 4095] \
+	[172.17.0.10].33916 [8.8.8.8].53  \
+	dns QUERY,NOERROR,45248,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:23:59.092204 [#5 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].33916  \
+	dns QUERY,NOERROR,45248,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72067,dfw06s47-in-f14.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72067,dfw06s47-in-f206.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71550,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71550,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71550,ns2.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71550,ns1.google.com \
+	4 ns1.google.com,IN,A,331824,216.239.32.10 \
+	ns3.google.com,IN,A,157822,216.239.36.10 \
+	ns4.google.com,IN,A,157822,216.239.38.10 \
+	ns2.google.com,IN,A,157822,216.239.34.10
+[73] 2016-10-20 15:24:06.339145 [#6 dns.pcap-dist 4095] \
+	[172.17.0.10].58176 [8.8.8.8].53  \
+	dns QUERY,NOERROR,25433,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:06.340820 [#7 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].58176  \
+	dns QUERY,NOERROR,25433,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72059,dfw06s47-in-f206.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72059,dfw06s47-in-f14.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71542,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71542,ns1.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71542,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71542,ns2.google.com \
+	4 ns1.google.com,IN,A,331816,216.239.32.10 \
+	ns3.google.com,IN,A,157814,216.239.36.10 \
+	ns4.google.com,IN,A,157814,216.239.38.10 \
+	ns2.google.com,IN,A,157814,216.239.34.10
+[73] 2016-10-20 15:24:07.353123 [#8 dns.pcap-dist 4095] \
+	[172.17.0.10].34607 [8.8.8.8].53  \
+	dns QUERY,NOERROR,8470,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:07.354682 [#9 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].34607  \
+	dns QUERY,NOERROR,8470,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72058,dfw06s47-in-f14.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72058,dfw06s47-in-f206.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71541,ns1.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71541,ns2.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71541,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71541,ns3.google.com \
+	4 ns1.google.com,IN,A,331815,216.239.32.10 \
+	ns3.google.com,IN,A,157813,216.239.36.10 \
+	ns4.google.com,IN,A,157813,216.239.38.10 \
+	ns2.google.com,IN,A,157813,216.239.34.10
+[73] 2016-10-20 15:24:08.368516 [#10 dns.pcap-dist 4095] \
+	[172.17.0.10].37149 [8.8.8.8].53  \
+	dns QUERY,NOERROR,44985,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:08.370119 [#11 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].37149  \
+	dns QUERY,NOERROR,44985,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72057,dfw06s47-in-f206.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72057,dfw06s47-in-f14.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71540,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71540,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71540,ns1.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71540,ns2.google.com \
+	4 ns1.google.com,IN,A,331814,216.239.32.10 \
+	ns3.google.com,IN,A,157812,216.239.36.10 \
+	ns4.google.com,IN,A,157812,216.239.38.10 \
+	ns2.google.com,IN,A,157812,216.239.34.10
+[73] 2016-10-20 15:24:09.384057 [#12 dns.pcap-dist 4095] \
+	[172.17.0.10].52368 [8.8.8.8].53  \
+	dns QUERY,NOERROR,22980,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:09.385463 [#13 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].52368  \
+	dns QUERY,NOERROR,22980,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72056,dfw06s47-in-f14.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72056,dfw06s47-in-f206.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71539,ns2.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71539,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71539,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71539,ns1.google.com \
+	4 ns1.google.com,IN,A,331813,216.239.32.10 \
+	ns3.google.com,IN,A,157811,216.239.36.10 \
+	ns4.google.com,IN,A,157811,216.239.38.10 \
+	ns2.google.com,IN,A,157811,216.239.34.10
+[73] 2016-10-20 15:24:10.398099 [#14 dns.pcap-dist 4095] \
+	[172.17.0.10].34426 [8.8.8.8].53  \
+	dns QUERY,NOERROR,25431,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:10.400317 [#15 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].34426  \
+	dns QUERY,NOERROR,25431,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72055,dfw06s47-in-f206.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72055,dfw06s47-in-f14.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71538,ns1.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71538,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71538,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71538,ns2.google.com \
+	4 ns1.google.com,IN,A,331812,216.239.32.10 \
+	ns3.google.com,IN,A,157810,216.239.36.10 \
+	ns4.google.com,IN,A,157810,216.239.38.10 \
+	ns2.google.com,IN,A,157810,216.239.34.10
+[73] 2016-10-20 15:24:11.412133 [#16 dns.pcap-dist 4095] \
+	[172.17.0.10].51181 [8.8.8.8].53  \
+	dns QUERY,NOERROR,47411,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:11.413370 [#17 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].51181  \
+	dns QUERY,NOERROR,47411,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72054,dfw06s47-in-f14.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72054,dfw06s47-in-f206.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71537,ns2.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71537,ns1.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71537,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71537,ns4.google.com \
+	4 ns1.google.com,IN,A,331811,216.239.32.10 \
+	ns3.google.com,IN,A,157809,216.239.36.10 \
+	ns4.google.com,IN,A,157809,216.239.38.10 \
+	ns2.google.com,IN,A,157809,216.239.34.10
+[73] 2016-10-20 15:24:18.452451 [#18 dns.pcap-dist 4095] \
+	[172.17.0.10].40224 [8.8.8.8].53  \
+	dns QUERY,NOERROR,60808,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:18.454030 [#19 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].40224  \
+	dns QUERY,NOERROR,60808,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72047,dfw06s47-in-f206.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72047,dfw06s47-in-f14.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71530,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71530,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71530,ns2.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71530,ns1.google.com \
+	4 ns1.google.com,IN,A,331804,216.239.32.10 \
+	ns3.google.com,IN,A,157802,216.239.36.10 \
+	ns4.google.com,IN,A,157802,216.239.38.10 \
+	ns2.google.com,IN,A,157802,216.239.34.10
+[73] 2016-10-20 15:24:19.467324 [#20 dns.pcap-dist 4095] \
+	[172.17.0.10].60457 [8.8.8.8].53  \
+	dns QUERY,NOERROR,25543,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:19.468895 [#21 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].60457  \
+	dns QUERY,NOERROR,25543,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72046,dfw06s47-in-f14.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72046,dfw06s47-in-f206.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71529,ns2.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71529,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71529,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71529,ns1.google.com \
+	4 ns1.google.com,IN,A,331803,216.239.32.10 \
+	ns3.google.com,IN,A,157801,216.239.36.10 \
+	ns4.google.com,IN,A,157801,216.239.38.10 \
+	ns2.google.com,IN,A,157801,216.239.34.10
+[73] 2016-10-20 15:24:20.482188 [#22 dns.pcap-dist 4095] \
+	[172.17.0.10].56022 [8.8.8.8].53  \
+	dns QUERY,NOERROR,25911,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:20.483927 [#23 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].56022  \
+	dns QUERY,NOERROR,25911,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72045,dfw06s47-in-f206.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72045,dfw06s47-in-f14.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71528,ns1.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71528,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71528,ns2.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71528,ns3.google.com \
+	4 ns1.google.com,IN,A,331802,216.239.32.10 \
+	ns3.google.com,IN,A,157800,216.239.36.10 \
+	ns4.google.com,IN,A,157800,216.239.38.10 \
+	ns2.google.com,IN,A,157800,216.239.34.10
+[73] 2016-10-20 15:24:21.495324 [#24 dns.pcap-dist 4095] \
+	[172.17.0.10].42978 [8.8.8.8].53  \
+	dns QUERY,NOERROR,37698,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:21.496815 [#25 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].42978  \
+	dns QUERY,NOERROR,37698,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72044,dfw06s47-in-f14.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72044,dfw06s47-in-f206.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71527,ns1.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71527,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71527,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71527,ns2.google.com \
+	4 ns1.google.com,IN,A,331801,216.239.32.10 \
+	ns3.google.com,IN,A,157799,216.239.36.10 \
+	ns4.google.com,IN,A,157799,216.239.38.10 \
+	ns2.google.com,IN,A,157799,216.239.34.10
+[73] 2016-10-20 15:24:22.510176 [#26 dns.pcap-dist 4095] \
+	[172.17.0.10].50599 [8.8.8.8].53  \
+	dns QUERY,NOERROR,32142,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:22.511746 [#27 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].50599  \
+	dns QUERY,NOERROR,32142,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72043,dfw06s47-in-f206.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72043,dfw06s47-in-f14.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71526,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71526,ns1.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71526,ns2.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71526,ns4.google.com \
+	4 ns1.google.com,IN,A,331800,216.239.32.10 \
+	ns3.google.com,IN,A,157798,216.239.36.10 \
+	ns4.google.com,IN,A,157798,216.239.38.10 \
+	ns2.google.com,IN,A,157798,216.239.34.10
+[73] 2016-10-20 15:24:23.527449 [#28 dns.pcap-dist 4095] \
+	[172.17.0.10].60063 [8.8.8.8].53  \
+	dns QUERY,NOERROR,18886,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:23.529385 [#29 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].60063  \
+	dns QUERY,NOERROR,18886,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72042,dfw06s47-in-f14.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72042,dfw06s47-in-f206.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71525,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71525,ns1.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71525,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71525,ns2.google.com \
+	4 ns1.google.com,IN,A,331799,216.239.32.10 \
+	ns3.google.com,IN,A,157797,216.239.36.10 \
+	ns4.google.com,IN,A,157797,216.239.38.10 \
+	ns2.google.com,IN,A,157797,216.239.34.10
+[73] 2016-10-20 15:24:24.544538 [#30 dns.pcap-dist 4095] \
+	[172.17.0.10].60469 [8.8.8.8].53  \
+	dns QUERY,NOERROR,33139,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:24.546172 [#31 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].60469  \
+	dns QUERY,NOERROR,33139,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72041,dfw06s47-in-f206.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72041,dfw06s47-in-f14.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71524,ns2.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71524,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71524,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71524,ns1.google.com \
+	4 ns1.google.com,IN,A,331798,216.239.32.10 \
+	ns3.google.com,IN,A,157796,216.239.36.10 \
+	ns4.google.com,IN,A,157796,216.239.38.10 \
+	ns2.google.com,IN,A,157796,216.239.34.10
+[73] 2016-10-20 15:24:25.562608 [#32 dns.pcap-dist 4095] \
+	[172.17.0.10].33507 [8.8.8.8].53  \
+	dns QUERY,NOERROR,59258,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:25.564509 [#33 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].33507  \
+	dns QUERY,NOERROR,59258,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72040,dfw06s47-in-f14.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72040,dfw06s47-in-f206.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71523,ns1.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71523,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71523,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71523,ns2.google.com \
+	4 ns1.google.com,IN,A,331797,216.239.32.10 \
+	ns3.google.com,IN,A,157795,216.239.36.10 \
+	ns4.google.com,IN,A,157795,216.239.38.10 \
+	ns2.google.com,IN,A,157795,216.239.34.10
+-- not PTR
+[56] 2016-10-20 15:23:01.075993 [#0 dns.pcap-dist 4095] \
+	[172.17.0.10].53199 [8.8.8.8].53  \
+	dns QUERY,NOERROR,59311,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:23:01.077982 [#1 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].53199  \
+	dns QUERY,NOERROR,59311,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,44,216.58.218.206 \
+	4 google.com,IN,NS,157880,ns4.google.com \
+	google.com,IN,NS,157880,ns3.google.com \
+	google.com,IN,NS,157880,ns1.google.com \
+	google.com,IN,NS,157880,ns2.google.com \
+	4 ns2.google.com,IN,A,157880,216.239.34.10 \
+	ns1.google.com,IN,A,331882,216.239.32.10 \
+	ns3.google.com,IN,A,157880,216.239.36.10 \
+	ns4.google.com,IN,A,157880,216.239.38.10
+[56] 2016-10-20 15:23:01.087291 [#2 dns.pcap-dist 4095] \
+	[172.17.0.10].40043 [8.8.8.8].53  \
+	dns QUERY,NOERROR,5337,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:23:01.088733 [#3 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].40043  \
+	dns QUERY,NOERROR,5337,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,44,216.58.218.206 \
+	4 google.com,IN,NS,157880,ns1.google.com \
+	google.com,IN,NS,157880,ns2.google.com \
+	google.com,IN,NS,157880,ns3.google.com \
+	google.com,IN,NS,157880,ns4.google.com \
+	4 ns2.google.com,IN,A,157880,216.239.34.10 \
+	ns1.google.com,IN,A,331882,216.239.32.10 \
+	ns3.google.com,IN,A,157880,216.239.36.10 \
+	ns4.google.com,IN,A,157880,216.239.38.10
+[56] 2016-10-20 15:23:10.322117 [#4 dns.pcap-dist 4095] \
+	[172.17.0.10].37953 [8.8.8.8].53  \
+	dns QUERY,NOERROR,22982,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:23:10.323399 [#5 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].37953  \
+	dns QUERY,NOERROR,22982,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,34,216.58.218.206 \
+	4 google.com,IN,NS,157870,ns4.google.com \
+	google.com,IN,NS,157870,ns1.google.com \
+	google.com,IN,NS,157870,ns2.google.com \
+	google.com,IN,NS,157870,ns3.google.com \
+	4 ns2.google.com,IN,A,157870,216.239.34.10 \
+	ns1.google.com,IN,A,331872,216.239.32.10 \
+	ns3.google.com,IN,A,157870,216.239.36.10 \
+	ns4.google.com,IN,A,157870,216.239.38.10
+[56] 2016-10-20 15:23:52.860937 [#6 dns.pcap-dist 4095] \
+	[172.17.0.10].40953 [8.8.8.8].53  \
+	dns QUERY,NOERROR,22531,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:23:52.863771 [#7 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].40953  \
+	dns QUERY,NOERROR,22531,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,297,216.58.218.206 \
+	4 google.com,IN,NS,157828,ns2.google.com \
+	google.com,IN,NS,157828,ns4.google.com \
+	google.com,IN,NS,157828,ns1.google.com \
+	google.com,IN,NS,157828,ns3.google.com \
+	4 ns2.google.com,IN,A,157828,216.239.34.10 \
+	ns1.google.com,IN,A,331830,216.239.32.10 \
+	ns3.google.com,IN,A,157828,216.239.36.10 \
+	ns4.google.com,IN,A,157828,216.239.38.10
+[56] 2016-10-20 15:23:59.083869 [#8 dns.pcap-dist 4095] \
+	[172.17.0.10].45174 [8.8.8.8].53  \
+	dns QUERY,NOERROR,58510,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:23:59.086104 [#9 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].45174  \
+	dns QUERY,NOERROR,58510,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,291,216.58.218.206 \
+	4 google.com,IN,NS,157822,ns2.google.com \
+	google.com,IN,NS,157822,ns3.google.com \
+	google.com,IN,NS,157822,ns1.google.com \
+	google.com,IN,NS,157822,ns4.google.com \
+	4 ns2.google.com,IN,A,157822,216.239.34.10 \
+	ns1.google.com,IN,A,331824,216.239.32.10 \
+	ns3.google.com,IN,A,157822,216.239.36.10 \
+	ns4.google.com,IN,A,157822,216.239.38.10
+[56] 2016-10-20 15:24:04.323868 [#10 dns.pcap-dist 4095] \
+	[172.17.0.10].43559 [8.8.8.8].53  \
+	dns QUERY,NOERROR,49483,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:04.325597 [#11 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].43559  \
+	dns QUERY,NOERROR,49483,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,285,216.58.218.206 \
+	4 google.com,IN,NS,157816,ns4.google.com \
+	google.com,IN,NS,157816,ns3.google.com \
+	google.com,IN,NS,157816,ns1.google.com \
+	google.com,IN,NS,157816,ns2.google.com \
+	4 ns2.google.com,IN,A,157816,216.239.34.10 \
+	ns1.google.com,IN,A,331818,216.239.32.10 \
+	ns3.google.com,IN,A,157816,216.239.36.10 \
+	ns4.google.com,IN,A,157816,216.239.38.10
+[56] 2016-10-20 15:24:06.332239 [#12 dns.pcap-dist 4095] \
+	[172.17.0.10].54859 [8.8.8.8].53  \
+	dns QUERY,NOERROR,31669,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:06.333743 [#13 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].54859  \
+	dns QUERY,NOERROR,31669,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,283,216.58.218.206 \
+	4 google.com,IN,NS,157814,ns2.google.com \
+	google.com,IN,NS,157814,ns1.google.com \
+	google.com,IN,NS,157814,ns4.google.com \
+	google.com,IN,NS,157814,ns3.google.com \
+	4 ns2.google.com,IN,A,157814,216.239.34.10 \
+	ns1.google.com,IN,A,331816,216.239.32.10 \
+	ns3.google.com,IN,A,157814,216.239.36.10 \
+	ns4.google.com,IN,A,157814,216.239.38.10
+[56] 2016-10-20 15:24:07.346429 [#14 dns.pcap-dist 4095] \
+	[172.17.0.10].41266 [8.8.8.8].53  \
+	dns QUERY,NOERROR,63798,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:07.348160 [#15 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].41266  \
+	dns QUERY,NOERROR,63798,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,282,216.58.218.206 \
+	4 google.com,IN,NS,157813,ns4.google.com \
+	google.com,IN,NS,157813,ns1.google.com \
+	google.com,IN,NS,157813,ns3.google.com \
+	google.com,IN,NS,157813,ns2.google.com \
+	4 ns2.google.com,IN,A,157813,216.239.34.10 \
+	ns1.google.com,IN,A,331815,216.239.32.10 \
+	ns3.google.com,IN,A,157813,216.239.36.10 \
+	ns4.google.com,IN,A,157813,216.239.38.10
+[56] 2016-10-20 15:24:08.360528 [#16 dns.pcap-dist 4095] \
+	[172.17.0.10].60437 [8.8.8.8].53  \
+	dns QUERY,NOERROR,60258,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:08.362206 [#17 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].60437  \
+	dns QUERY,NOERROR,60258,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,281,216.58.218.206 \
+	4 google.com,IN,NS,157812,ns3.google.com \
+	google.com,IN,NS,157812,ns2.google.com \
+	google.com,IN,NS,157812,ns4.google.com \
+	google.com,IN,NS,157812,ns1.google.com \
+	4 ns2.google.com,IN,A,157812,216.239.34.10 \
+	ns1.google.com,IN,A,331814,216.239.32.10 \
+	ns3.google.com,IN,A,157812,216.239.36.10 \
+	ns4.google.com,IN,A,157812,216.239.38.10
+[56] 2016-10-20 15:24:09.375942 [#18 dns.pcap-dist 4095] \
+	[172.17.0.10].53820 [8.8.8.8].53  \
+	dns QUERY,NOERROR,45512,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:09.378425 [#19 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].53820  \
+	dns QUERY,NOERROR,45512,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,280,216.58.218.206 \
+	4 google.com,IN,NS,157811,ns3.google.com \
+	google.com,IN,NS,157811,ns4.google.com \
+	google.com,IN,NS,157811,ns1.google.com \
+	google.com,IN,NS,157811,ns2.google.com \
+	4 ns2.google.com,IN,A,157811,216.239.34.10 \
+	ns1.google.com,IN,A,331813,216.239.32.10 \
+	ns3.google.com,IN,A,157811,216.239.36.10 \
+	ns4.google.com,IN,A,157811,216.239.38.10
+[56] 2016-10-20 15:24:10.391358 [#20 dns.pcap-dist 4095] \
+	[172.17.0.10].47637 [8.8.8.8].53  \
+	dns QUERY,NOERROR,1834,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:10.392886 [#21 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].47637  \
+	dns QUERY,NOERROR,1834,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,279,216.58.218.206 \
+	4 google.com,IN,NS,157810,ns1.google.com \
+	google.com,IN,NS,157810,ns2.google.com \
+	google.com,IN,NS,157810,ns4.google.com \
+	google.com,IN,NS,157810,ns3.google.com \
+	4 ns2.google.com,IN,A,157810,216.239.34.10 \
+	ns1.google.com,IN,A,331812,216.239.32.10 \
+	ns3.google.com,IN,A,157810,216.239.36.10 \
+	ns4.google.com,IN,A,157810,216.239.38.10
+[56] 2016-10-20 15:24:11.406297 [#22 dns.pcap-dist 4095] \
+	[172.17.0.10].41059 [8.8.8.8].53  \
+	dns QUERY,NOERROR,48432,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:11.407460 [#23 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].41059  \
+	dns QUERY,NOERROR,48432,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,278,216.58.218.206 \
+	4 google.com,IN,NS,157809,ns3.google.com \
+	google.com,IN,NS,157809,ns4.google.com \
+	google.com,IN,NS,157809,ns2.google.com \
+	google.com,IN,NS,157809,ns1.google.com \
+	4 ns2.google.com,IN,A,157809,216.239.34.10 \
+	ns1.google.com,IN,A,331811,216.239.32.10 \
+	ns3.google.com,IN,A,157809,216.239.36.10 \
+	ns4.google.com,IN,A,157809,216.239.38.10
+[56] 2016-10-20 15:24:12.419936 [#24 dns.pcap-dist 4095] \
+	[172.17.0.10].32976 [8.8.8.8].53  \
+	dns QUERY,NOERROR,12038,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:12.421228 [#25 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].32976  \
+	dns QUERY,NOERROR,12038,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,277,216.58.218.206 \
+	4 google.com,IN,NS,157808,ns2.google.com \
+	google.com,IN,NS,157808,ns3.google.com \
+	google.com,IN,NS,157808,ns1.google.com \
+	google.com,IN,NS,157808,ns4.google.com \
+	4 ns2.google.com,IN,A,157808,216.239.34.10 \
+	ns1.google.com,IN,A,331810,216.239.32.10 \
+	ns3.google.com,IN,A,157808,216.239.36.10 \
+	ns4.google.com,IN,A,157808,216.239.38.10
+[56] 2016-10-20 15:24:14.428524 [#26 dns.pcap-dist 4095] \
+	[172.17.0.10].53467 [8.8.8.8].53  \
+	dns QUERY,NOERROR,11614,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:14.429863 [#27 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].53467  \
+	dns QUERY,NOERROR,11614,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,275,216.58.218.206 \
+	4 google.com,IN,NS,157806,ns3.google.com \
+	google.com,IN,NS,157806,ns1.google.com \
+	google.com,IN,NS,157806,ns4.google.com \
+	google.com,IN,NS,157806,ns2.google.com \
+	4 ns2.google.com,IN,A,157806,216.239.34.10 \
+	ns1.google.com,IN,A,331808,216.239.32.10 \
+	ns3.google.com,IN,A,157806,216.239.36.10 \
+	ns4.google.com,IN,A,157806,216.239.38.10
+[56] 2016-10-20 15:24:16.435733 [#28 dns.pcap-dist 4095] \
+	[172.17.0.10].41532 [8.8.8.8].53  \
+	dns QUERY,NOERROR,59173,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:16.437471 [#29 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].41532  \
+	dns QUERY,NOERROR,59173,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,273,216.58.218.206 \
+	4 google.com,IN,NS,157804,ns1.google.com \
+	google.com,IN,NS,157804,ns3.google.com \
+	google.com,IN,NS,157804,ns2.google.com \
+	google.com,IN,NS,157804,ns4.google.com \
+	4 ns2.google.com,IN,A,157804,216.239.34.10 \
+	ns1.google.com,IN,A,331806,216.239.32.10 \
+	ns3.google.com,IN,A,157804,216.239.36.10 \
+	ns4.google.com,IN,A,157804,216.239.38.10
+[56] 2016-10-20 15:24:18.445519 [#30 dns.pcap-dist 4095] \
+	[172.17.0.10].44982 [8.8.8.8].53  \
+	dns QUERY,NOERROR,45535,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:18.446775 [#31 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].44982  \
+	dns QUERY,NOERROR,45535,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,271,216.58.218.206 \
+	4 google.com,IN,NS,157802,ns4.google.com \
+	google.com,IN,NS,157802,ns2.google.com \
+	google.com,IN,NS,157802,ns1.google.com \
+	google.com,IN,NS,157802,ns3.google.com \
+	4 ns2.google.com,IN,A,157802,216.239.34.10 \
+	ns1.google.com,IN,A,331804,216.239.32.10 \
+	ns3.google.com,IN,A,157802,216.239.36.10 \
+	ns4.google.com,IN,A,157802,216.239.38.10
+[56] 2016-10-20 15:24:19.460087 [#32 dns.pcap-dist 4095] \
+	[172.17.0.10].45658 [8.8.8.8].53  \
+	dns QUERY,NOERROR,64325,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:19.462224 [#33 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].45658  \
+	dns QUERY,NOERROR,64325,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,270,216.58.218.206 \
+	4 google.com,IN,NS,157801,ns1.google.com \
+	google.com,IN,NS,157801,ns3.google.com \
+	google.com,IN,NS,157801,ns4.google.com \
+	google.com,IN,NS,157801,ns2.google.com \
+	4 ns2.google.com,IN,A,157801,216.239.34.10 \
+	ns1.google.com,IN,A,331803,216.239.32.10 \
+	ns3.google.com,IN,A,157801,216.239.36.10 \
+	ns4.google.com,IN,A,157801,216.239.38.10
+[56] 2016-10-20 15:24:20.475086 [#34 dns.pcap-dist 4095] \
+	[172.17.0.10].59762 [8.8.8.8].53  \
+	dns QUERY,NOERROR,20736,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:20.476841 [#35 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].59762  \
+	dns QUERY,NOERROR,20736,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,269,216.58.218.206 \
+	4 google.com,IN,NS,157800,ns3.google.com \
+	google.com,IN,NS,157800,ns1.google.com \
+	google.com,IN,NS,157800,ns4.google.com \
+	google.com,IN,NS,157800,ns2.google.com \
+	4 ns2.google.com,IN,A,157800,216.239.34.10 \
+	ns1.google.com,IN,A,331802,216.239.32.10 \
+	ns3.google.com,IN,A,157800,216.239.36.10 \
+	ns4.google.com,IN,A,157800,216.239.38.10
+[56] 2016-10-20 15:24:21.489468 [#36 dns.pcap-dist 4095] \
+	[172.17.0.10].37669 [8.8.8.8].53  \
+	dns QUERY,NOERROR,64358,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:21.490573 [#37 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].37669  \
+	dns QUERY,NOERROR,64358,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,268,216.58.218.206 \
+	4 google.com,IN,NS,157799,ns2.google.com \
+	google.com,IN,NS,157799,ns1.google.com \
+	google.com,IN,NS,157799,ns4.google.com \
+	google.com,IN,NS,157799,ns3.google.com \
+	4 ns2.google.com,IN,A,157799,216.239.34.10 \
+	ns1.google.com,IN,A,331801,216.239.32.10 \
+	ns3.google.com,IN,A,157799,216.239.36.10 \
+	ns4.google.com,IN,A,157799,216.239.38.10
+[56] 2016-10-20 15:24:22.502667 [#38 dns.pcap-dist 4095] \
+	[172.17.0.10].49829 [8.8.8.8].53  \
+	dns QUERY,NOERROR,54706,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:22.504738 [#39 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].49829  \
+	dns QUERY,NOERROR,54706,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,267,216.58.218.206 \
+	4 google.com,IN,NS,157798,ns2.google.com \
+	google.com,IN,NS,157798,ns4.google.com \
+	google.com,IN,NS,157798,ns3.google.com \
+	google.com,IN,NS,157798,ns1.google.com \
+	4 ns2.google.com,IN,A,157798,216.239.34.10 \
+	ns1.google.com,IN,A,331800,216.239.32.10 \
+	ns3.google.com,IN,A,157798,216.239.36.10 \
+	ns4.google.com,IN,A,157798,216.239.38.10
+[56] 2016-10-20 15:24:23.520203 [#40 dns.pcap-dist 4095] \
+	[172.17.0.10].44980 [8.8.8.8].53  \
+	dns QUERY,NOERROR,41808,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:23.521976 [#41 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].44980  \
+	dns QUERY,NOERROR,41808,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,266,216.58.218.206 \
+	4 google.com,IN,NS,157797,ns2.google.com \
+	google.com,IN,NS,157797,ns4.google.com \
+	google.com,IN,NS,157797,ns1.google.com \
+	google.com,IN,NS,157797,ns3.google.com \
+	4 ns2.google.com,IN,A,157797,216.239.34.10 \
+	ns1.google.com,IN,A,331799,216.239.32.10 \
+	ns3.google.com,IN,A,157797,216.239.36.10 \
+	ns4.google.com,IN,A,157797,216.239.38.10
+[56] 2016-10-20 15:24:24.537264 [#42 dns.pcap-dist 4095] \
+	[172.17.0.10].42042 [8.8.8.8].53  \
+	dns QUERY,NOERROR,10624,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:24.539398 [#43 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].42042  \
+	dns QUERY,NOERROR,10624,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,265,216.58.218.206 \
+	4 google.com,IN,NS,157796,ns3.google.com \
+	google.com,IN,NS,157796,ns4.google.com \
+	google.com,IN,NS,157796,ns1.google.com \
+	google.com,IN,NS,157796,ns2.google.com \
+	4 ns2.google.com,IN,A,157796,216.239.34.10 \
+	ns1.google.com,IN,A,331798,216.239.32.10 \
+	ns3.google.com,IN,A,157796,216.239.36.10 \
+	ns4.google.com,IN,A,157796,216.239.38.10
+[56] 2016-10-20 15:24:25.554744 [#44 dns.pcap-dist 4095] \
+	[172.17.0.10].45703 [8.8.8.8].53  \
+	dns QUERY,NOERROR,61415,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:25.556513 [#45 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].45703  \
+	dns QUERY,NOERROR,61415,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,264,216.58.218.206 \
+	4 google.com,IN,NS,157795,ns3.google.com \
+	google.com,IN,NS,157795,ns4.google.com \
+	google.com,IN,NS,157795,ns2.google.com \
+	google.com,IN,NS,157795,ns1.google.com \
+	4 ns2.google.com,IN,A,157795,216.239.34.10 \
+	ns1.google.com,IN,A,331797,216.239.32.10 \
+	ns3.google.com,IN,A,157795,216.239.36.10 \
+	ns4.google.com,IN,A,157795,216.239.38.10
+[56] 2016-10-20 15:24:26.572784 [#46 dns.pcap-dist 4095] \
+	[172.17.0.10].46798 [8.8.8.8].53  \
+	dns QUERY,NOERROR,17700,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:26.574350 [#47 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].46798  \
+	dns QUERY,NOERROR,17700,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,263,216.58.218.206 \
+	4 google.com,IN,NS,157794,ns1.google.com \
+	google.com,IN,NS,157794,ns4.google.com \
+	google.com,IN,NS,157794,ns3.google.com \
+	google.com,IN,NS,157794,ns2.google.com \
+	4 ns2.google.com,IN,A,157794,216.239.34.10 \
+	ns1.google.com,IN,A,331796,216.239.32.10 \
+	ns3.google.com,IN,A,157794,216.239.36.10 \
+	ns4.google.com,IN,A,157794,216.239.38.10
+-- only 1
+[56] 2016-10-20 15:23:01.075993 [#0 dns.pcap-dist 4095] \
+	[172.17.0.10].53199 [8.8.8.8].53  \
+	dns QUERY,NOERROR,59311,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:23:01.077982 [#1 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].53199  \
+	dns QUERY,NOERROR,59311,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,44,216.58.218.206 \
+	4 google.com,IN,NS,157880,ns4.google.com \
+	google.com,IN,NS,157880,ns3.google.com \
+	google.com,IN,NS,157880,ns1.google.com \
+	google.com,IN,NS,157880,ns2.google.com \
+	4 ns2.google.com,IN,A,157880,216.239.34.10 \
+	ns1.google.com,IN,A,331882,216.239.32.10 \
+	ns3.google.com,IN,A,157880,216.239.36.10 \
+	ns4.google.com,IN,A,157880,216.239.38.10
+[56] 2016-10-20 15:23:01.087291 [#2 dns.pcap-dist 4095] \
+	[172.17.0.10].40043 [8.8.8.8].53  \
+	dns QUERY,NOERROR,5337,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:23:01.088733 [#3 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].40043  \
+	dns QUERY,NOERROR,5337,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,44,216.58.218.206 \
+	4 google.com,IN,NS,157880,ns1.google.com \
+	google.com,IN,NS,157880,ns2.google.com \
+	google.com,IN,NS,157880,ns3.google.com \
+	google.com,IN,NS,157880,ns4.google.com \
+	4 ns2.google.com,IN,A,157880,216.239.34.10 \
+	ns1.google.com,IN,A,331882,216.239.32.10 \
+	ns3.google.com,IN,A,157880,216.239.36.10 \
+	ns4.google.com,IN,A,157880,216.239.38.10
+[56] 2016-10-20 15:23:10.322117 [#4 dns.pcap-dist 4095] \
+	[172.17.0.10].37953 [8.8.8.8].53  \
+	dns QUERY,NOERROR,22982,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:23:10.323399 [#5 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].37953  \
+	dns QUERY,NOERROR,22982,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,34,216.58.218.206 \
+	4 google.com,IN,NS,157870,ns4.google.com \
+	google.com,IN,NS,157870,ns1.google.com \
+	google.com,IN,NS,157870,ns2.google.com \
+	google.com,IN,NS,157870,ns3.google.com \
+	4 ns2.google.com,IN,A,157870,216.239.34.10 \
+	ns1.google.com,IN,A,331872,216.239.32.10 \
+	ns3.google.com,IN,A,157870,216.239.36.10 \
+	ns4.google.com,IN,A,157870,216.239.38.10
+[56] 2016-10-20 15:23:52.860937 [#6 dns.pcap-dist 4095] \
+	[172.17.0.10].40953 [8.8.8.8].53  \
+	dns QUERY,NOERROR,22531,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:23:52.863771 [#7 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].40953  \
+	dns QUERY,NOERROR,22531,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,297,216.58.218.206 \
+	4 google.com,IN,NS,157828,ns2.google.com \
+	google.com,IN,NS,157828,ns4.google.com \
+	google.com,IN,NS,157828,ns1.google.com \
+	google.com,IN,NS,157828,ns3.google.com \
+	4 ns2.google.com,IN,A,157828,216.239.34.10 \
+	ns1.google.com,IN,A,331830,216.239.32.10 \
+	ns3.google.com,IN,A,157828,216.239.36.10 \
+	ns4.google.com,IN,A,157828,216.239.38.10
+[56] 2016-10-20 15:23:59.083869 [#8 dns.pcap-dist 4095] \
+	[172.17.0.10].45174 [8.8.8.8].53  \
+	dns QUERY,NOERROR,58510,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:23:59.086104 [#9 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].45174  \
+	dns QUERY,NOERROR,58510,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,291,216.58.218.206 \
+	4 google.com,IN,NS,157822,ns2.google.com \
+	google.com,IN,NS,157822,ns3.google.com \
+	google.com,IN,NS,157822,ns1.google.com \
+	google.com,IN,NS,157822,ns4.google.com \
+	4 ns2.google.com,IN,A,157822,216.239.34.10 \
+	ns1.google.com,IN,A,331824,216.239.32.10 \
+	ns3.google.com,IN,A,157822,216.239.36.10 \
+	ns4.google.com,IN,A,157822,216.239.38.10
+[56] 2016-10-20 15:24:04.323868 [#10 dns.pcap-dist 4095] \
+	[172.17.0.10].43559 [8.8.8.8].53  \
+	dns QUERY,NOERROR,49483,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:04.325597 [#11 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].43559  \
+	dns QUERY,NOERROR,49483,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,285,216.58.218.206 \
+	4 google.com,IN,NS,157816,ns4.google.com \
+	google.com,IN,NS,157816,ns3.google.com \
+	google.com,IN,NS,157816,ns1.google.com \
+	google.com,IN,NS,157816,ns2.google.com \
+	4 ns2.google.com,IN,A,157816,216.239.34.10 \
+	ns1.google.com,IN,A,331818,216.239.32.10 \
+	ns3.google.com,IN,A,157816,216.239.36.10 \
+	ns4.google.com,IN,A,157816,216.239.38.10
+[56] 2016-10-20 15:24:06.332239 [#12 dns.pcap-dist 4095] \
+	[172.17.0.10].54859 [8.8.8.8].53  \
+	dns QUERY,NOERROR,31669,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:06.333743 [#13 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].54859  \
+	dns QUERY,NOERROR,31669,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,283,216.58.218.206 \
+	4 google.com,IN,NS,157814,ns2.google.com \
+	google.com,IN,NS,157814,ns1.google.com \
+	google.com,IN,NS,157814,ns4.google.com \
+	google.com,IN,NS,157814,ns3.google.com \
+	4 ns2.google.com,IN,A,157814,216.239.34.10 \
+	ns1.google.com,IN,A,331816,216.239.32.10 \
+	ns3.google.com,IN,A,157814,216.239.36.10 \
+	ns4.google.com,IN,A,157814,216.239.38.10
+[56] 2016-10-20 15:24:07.346429 [#14 dns.pcap-dist 4095] \
+	[172.17.0.10].41266 [8.8.8.8].53  \
+	dns QUERY,NOERROR,63798,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:07.348160 [#15 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].41266  \
+	dns QUERY,NOERROR,63798,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,282,216.58.218.206 \
+	4 google.com,IN,NS,157813,ns4.google.com \
+	google.com,IN,NS,157813,ns1.google.com \
+	google.com,IN,NS,157813,ns3.google.com \
+	google.com,IN,NS,157813,ns2.google.com \
+	4 ns2.google.com,IN,A,157813,216.239.34.10 \
+	ns1.google.com,IN,A,331815,216.239.32.10 \
+	ns3.google.com,IN,A,157813,216.239.36.10 \
+	ns4.google.com,IN,A,157813,216.239.38.10
+[56] 2016-10-20 15:24:08.360528 [#16 dns.pcap-dist 4095] \
+	[172.17.0.10].60437 [8.8.8.8].53  \
+	dns QUERY,NOERROR,60258,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:08.362206 [#17 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].60437  \
+	dns QUERY,NOERROR,60258,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,281,216.58.218.206 \
+	4 google.com,IN,NS,157812,ns3.google.com \
+	google.com,IN,NS,157812,ns2.google.com \
+	google.com,IN,NS,157812,ns4.google.com \
+	google.com,IN,NS,157812,ns1.google.com \
+	4 ns2.google.com,IN,A,157812,216.239.34.10 \
+	ns1.google.com,IN,A,331814,216.239.32.10 \
+	ns3.google.com,IN,A,157812,216.239.36.10 \
+	ns4.google.com,IN,A,157812,216.239.38.10
+[56] 2016-10-20 15:24:09.375942 [#18 dns.pcap-dist 4095] \
+	[172.17.0.10].53820 [8.8.8.8].53  \
+	dns QUERY,NOERROR,45512,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:09.378425 [#19 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].53820  \
+	dns QUERY,NOERROR,45512,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,280,216.58.218.206 \
+	4 google.com,IN,NS,157811,ns3.google.com \
+	google.com,IN,NS,157811,ns4.google.com \
+	google.com,IN,NS,157811,ns1.google.com \
+	google.com,IN,NS,157811,ns2.google.com \
+	4 ns2.google.com,IN,A,157811,216.239.34.10 \
+	ns1.google.com,IN,A,331813,216.239.32.10 \
+	ns3.google.com,IN,A,157811,216.239.36.10 \
+	ns4.google.com,IN,A,157811,216.239.38.10
+[56] 2016-10-20 15:24:10.391358 [#20 dns.pcap-dist 4095] \
+	[172.17.0.10].47637 [8.8.8.8].53  \
+	dns QUERY,NOERROR,1834,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:10.392886 [#21 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].47637  \
+	dns QUERY,NOERROR,1834,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,279,216.58.218.206 \
+	4 google.com,IN,NS,157810,ns1.google.com \
+	google.com,IN,NS,157810,ns2.google.com \
+	google.com,IN,NS,157810,ns4.google.com \
+	google.com,IN,NS,157810,ns3.google.com \
+	4 ns2.google.com,IN,A,157810,216.239.34.10 \
+	ns1.google.com,IN,A,331812,216.239.32.10 \
+	ns3.google.com,IN,A,157810,216.239.36.10 \
+	ns4.google.com,IN,A,157810,216.239.38.10
+[56] 2016-10-20 15:24:11.406297 [#22 dns.pcap-dist 4095] \
+	[172.17.0.10].41059 [8.8.8.8].53  \
+	dns QUERY,NOERROR,48432,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:11.407460 [#23 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].41059  \
+	dns QUERY,NOERROR,48432,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,278,216.58.218.206 \
+	4 google.com,IN,NS,157809,ns3.google.com \
+	google.com,IN,NS,157809,ns4.google.com \
+	google.com,IN,NS,157809,ns2.google.com \
+	google.com,IN,NS,157809,ns1.google.com \
+	4 ns2.google.com,IN,A,157809,216.239.34.10 \
+	ns1.google.com,IN,A,331811,216.239.32.10 \
+	ns3.google.com,IN,A,157809,216.239.36.10 \
+	ns4.google.com,IN,A,157809,216.239.38.10
+[56] 2016-10-20 15:24:12.419936 [#24 dns.pcap-dist 4095] \
+	[172.17.0.10].32976 [8.8.8.8].53  \
+	dns QUERY,NOERROR,12038,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:12.421228 [#25 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].32976  \
+	dns QUERY,NOERROR,12038,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,277,216.58.218.206 \
+	4 google.com,IN,NS,157808,ns2.google.com \
+	google.com,IN,NS,157808,ns3.google.com \
+	google.com,IN,NS,157808,ns1.google.com \
+	google.com,IN,NS,157808,ns4.google.com \
+	4 ns2.google.com,IN,A,157808,216.239.34.10 \
+	ns1.google.com,IN,A,331810,216.239.32.10 \
+	ns3.google.com,IN,A,157808,216.239.36.10 \
+	ns4.google.com,IN,A,157808,216.239.38.10
+[56] 2016-10-20 15:24:14.428524 [#26 dns.pcap-dist 4095] \
+	[172.17.0.10].53467 [8.8.8.8].53  \
+	dns QUERY,NOERROR,11614,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:14.429863 [#27 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].53467  \
+	dns QUERY,NOERROR,11614,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,275,216.58.218.206 \
+	4 google.com,IN,NS,157806,ns3.google.com \
+	google.com,IN,NS,157806,ns1.google.com \
+	google.com,IN,NS,157806,ns4.google.com \
+	google.com,IN,NS,157806,ns2.google.com \
+	4 ns2.google.com,IN,A,157806,216.239.34.10 \
+	ns1.google.com,IN,A,331808,216.239.32.10 \
+	ns3.google.com,IN,A,157806,216.239.36.10 \
+	ns4.google.com,IN,A,157806,216.239.38.10
+[56] 2016-10-20 15:24:16.435733 [#28 dns.pcap-dist 4095] \
+	[172.17.0.10].41532 [8.8.8.8].53  \
+	dns QUERY,NOERROR,59173,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:16.437471 [#29 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].41532  \
+	dns QUERY,NOERROR,59173,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,273,216.58.218.206 \
+	4 google.com,IN,NS,157804,ns1.google.com \
+	google.com,IN,NS,157804,ns3.google.com \
+	google.com,IN,NS,157804,ns2.google.com \
+	google.com,IN,NS,157804,ns4.google.com \
+	4 ns2.google.com,IN,A,157804,216.239.34.10 \
+	ns1.google.com,IN,A,331806,216.239.32.10 \
+	ns3.google.com,IN,A,157804,216.239.36.10 \
+	ns4.google.com,IN,A,157804,216.239.38.10
+[56] 2016-10-20 15:24:18.445519 [#30 dns.pcap-dist 4095] \
+	[172.17.0.10].44982 [8.8.8.8].53  \
+	dns QUERY,NOERROR,45535,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:18.446775 [#31 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].44982  \
+	dns QUERY,NOERROR,45535,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,271,216.58.218.206 \
+	4 google.com,IN,NS,157802,ns4.google.com \
+	google.com,IN,NS,157802,ns2.google.com \
+	google.com,IN,NS,157802,ns1.google.com \
+	google.com,IN,NS,157802,ns3.google.com \
+	4 ns2.google.com,IN,A,157802,216.239.34.10 \
+	ns1.google.com,IN,A,331804,216.239.32.10 \
+	ns3.google.com,IN,A,157802,216.239.36.10 \
+	ns4.google.com,IN,A,157802,216.239.38.10
+[56] 2016-10-20 15:24:19.460087 [#32 dns.pcap-dist 4095] \
+	[172.17.0.10].45658 [8.8.8.8].53  \
+	dns QUERY,NOERROR,64325,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:19.462224 [#33 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].45658  \
+	dns QUERY,NOERROR,64325,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,270,216.58.218.206 \
+	4 google.com,IN,NS,157801,ns1.google.com \
+	google.com,IN,NS,157801,ns3.google.com \
+	google.com,IN,NS,157801,ns4.google.com \
+	google.com,IN,NS,157801,ns2.google.com \
+	4 ns2.google.com,IN,A,157801,216.239.34.10 \
+	ns1.google.com,IN,A,331803,216.239.32.10 \
+	ns3.google.com,IN,A,157801,216.239.36.10 \
+	ns4.google.com,IN,A,157801,216.239.38.10
+[56] 2016-10-20 15:24:20.475086 [#34 dns.pcap-dist 4095] \
+	[172.17.0.10].59762 [8.8.8.8].53  \
+	dns QUERY,NOERROR,20736,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:20.476841 [#35 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].59762  \
+	dns QUERY,NOERROR,20736,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,269,216.58.218.206 \
+	4 google.com,IN,NS,157800,ns3.google.com \
+	google.com,IN,NS,157800,ns1.google.com \
+	google.com,IN,NS,157800,ns4.google.com \
+	google.com,IN,NS,157800,ns2.google.com \
+	4 ns2.google.com,IN,A,157800,216.239.34.10 \
+	ns1.google.com,IN,A,331802,216.239.32.10 \
+	ns3.google.com,IN,A,157800,216.239.36.10 \
+	ns4.google.com,IN,A,157800,216.239.38.10
+[56] 2016-10-20 15:24:21.489468 [#36 dns.pcap-dist 4095] \
+	[172.17.0.10].37669 [8.8.8.8].53  \
+	dns QUERY,NOERROR,64358,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:21.490573 [#37 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].37669  \
+	dns QUERY,NOERROR,64358,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,268,216.58.218.206 \
+	4 google.com,IN,NS,157799,ns2.google.com \
+	google.com,IN,NS,157799,ns1.google.com \
+	google.com,IN,NS,157799,ns4.google.com \
+	google.com,IN,NS,157799,ns3.google.com \
+	4 ns2.google.com,IN,A,157799,216.239.34.10 \
+	ns1.google.com,IN,A,331801,216.239.32.10 \
+	ns3.google.com,IN,A,157799,216.239.36.10 \
+	ns4.google.com,IN,A,157799,216.239.38.10
+[56] 2016-10-20 15:24:22.502667 [#38 dns.pcap-dist 4095] \
+	[172.17.0.10].49829 [8.8.8.8].53  \
+	dns QUERY,NOERROR,54706,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:22.504738 [#39 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].49829  \
+	dns QUERY,NOERROR,54706,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,267,216.58.218.206 \
+	4 google.com,IN,NS,157798,ns2.google.com \
+	google.com,IN,NS,157798,ns4.google.com \
+	google.com,IN,NS,157798,ns3.google.com \
+	google.com,IN,NS,157798,ns1.google.com \
+	4 ns2.google.com,IN,A,157798,216.239.34.10 \
+	ns1.google.com,IN,A,331800,216.239.32.10 \
+	ns3.google.com,IN,A,157798,216.239.36.10 \
+	ns4.google.com,IN,A,157798,216.239.38.10
+[56] 2016-10-20 15:24:23.520203 [#40 dns.pcap-dist 4095] \
+	[172.17.0.10].44980 [8.8.8.8].53  \
+	dns QUERY,NOERROR,41808,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:23.521976 [#41 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].44980  \
+	dns QUERY,NOERROR,41808,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,266,216.58.218.206 \
+	4 google.com,IN,NS,157797,ns2.google.com \
+	google.com,IN,NS,157797,ns4.google.com \
+	google.com,IN,NS,157797,ns1.google.com \
+	google.com,IN,NS,157797,ns3.google.com \
+	4 ns2.google.com,IN,A,157797,216.239.34.10 \
+	ns1.google.com,IN,A,331799,216.239.32.10 \
+	ns3.google.com,IN,A,157797,216.239.36.10 \
+	ns4.google.com,IN,A,157797,216.239.38.10
+[56] 2016-10-20 15:24:24.537264 [#42 dns.pcap-dist 4095] \
+	[172.17.0.10].42042 [8.8.8.8].53  \
+	dns QUERY,NOERROR,10624,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:24.539398 [#43 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].42042  \
+	dns QUERY,NOERROR,10624,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,265,216.58.218.206 \
+	4 google.com,IN,NS,157796,ns3.google.com \
+	google.com,IN,NS,157796,ns4.google.com \
+	google.com,IN,NS,157796,ns1.google.com \
+	google.com,IN,NS,157796,ns2.google.com \
+	4 ns2.google.com,IN,A,157796,216.239.34.10 \
+	ns1.google.com,IN,A,331798,216.239.32.10 \
+	ns3.google.com,IN,A,157796,216.239.36.10 \
+	ns4.google.com,IN,A,157796,216.239.38.10
+[56] 2016-10-20 15:24:25.554744 [#44 dns.pcap-dist 4095] \
+	[172.17.0.10].45703 [8.8.8.8].53  \
+	dns QUERY,NOERROR,61415,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:25.556513 [#45 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].45703  \
+	dns QUERY,NOERROR,61415,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,264,216.58.218.206 \
+	4 google.com,IN,NS,157795,ns3.google.com \
+	google.com,IN,NS,157795,ns4.google.com \
+	google.com,IN,NS,157795,ns2.google.com \
+	google.com,IN,NS,157795,ns1.google.com \
+	4 ns2.google.com,IN,A,157795,216.239.34.10 \
+	ns1.google.com,IN,A,331797,216.239.32.10 \
+	ns3.google.com,IN,A,157795,216.239.36.10 \
+	ns4.google.com,IN,A,157795,216.239.38.10
+[56] 2016-10-20 15:24:26.572784 [#46 dns.pcap-dist 4095] \
+	[172.17.0.10].46798 [8.8.8.8].53  \
+	dns QUERY,NOERROR,17700,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:26.574350 [#47 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].46798  \
+	dns QUERY,NOERROR,17700,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,263,216.58.218.206 \
+	4 google.com,IN,NS,157794,ns1.google.com \
+	google.com,IN,NS,157794,ns4.google.com \
+	google.com,IN,NS,157794,ns3.google.com \
+	google.com,IN,NS,157794,ns2.google.com \
+	4 ns2.google.com,IN,A,157794,216.239.34.10 \
+	ns1.google.com,IN,A,331796,216.239.32.10 \
+	ns3.google.com,IN,A,157794,216.239.36.10 \
+	ns4.google.com,IN,A,157794,216.239.38.10
+-- not 1
+[73] 2016-10-20 15:23:01.082865 [#0 dns.pcap-dist 4095] \
+	[172.17.0.10].57822 [8.8.8.8].53  \
+	dns QUERY,NOERROR,35665,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:23:01.084107 [#1 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].57822  \
+	dns QUERY,NOERROR,35665,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72125,dfw06s47-in-f14.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72125,dfw06s47-in-f206.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71608,ns2.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71608,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71608,ns1.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71608,ns4.google.com \
+	4 ns1.google.com,IN,A,331882,216.239.32.10 \
+	ns3.google.com,IN,A,157880,216.239.36.10 \
+	ns4.google.com,IN,A,157880,216.239.38.10 \
+	ns2.google.com,IN,A,157880,216.239.34.10
+[73] 2016-10-20 15:23:10.328324 [#2 dns.pcap-dist 4095] \
+	[172.17.0.10].48658 [8.8.8.8].53  \
+	dns QUERY,NOERROR,18718,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:23:10.329572 [#3 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].48658  \
+	dns QUERY,NOERROR,18718,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72115,dfw06s47-in-f206.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72115,dfw06s47-in-f14.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71598,ns2.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71598,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71598,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71598,ns1.google.com \
+	4 ns1.google.com,IN,A,331872,216.239.32.10 \
+	ns3.google.com,IN,A,157870,216.239.36.10 \
+	ns4.google.com,IN,A,157870,216.239.38.10 \
+	ns2.google.com,IN,A,157870,216.239.34.10
+[73] 2016-10-20 15:23:59.090911 [#4 dns.pcap-dist 4095] \
+	[172.17.0.10].33916 [8.8.8.8].53  \
+	dns QUERY,NOERROR,45248,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:23:59.092204 [#5 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].33916  \
+	dns QUERY,NOERROR,45248,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72067,dfw06s47-in-f14.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72067,dfw06s47-in-f206.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71550,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71550,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71550,ns2.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71550,ns1.google.com \
+	4 ns1.google.com,IN,A,331824,216.239.32.10 \
+	ns3.google.com,IN,A,157822,216.239.36.10 \
+	ns4.google.com,IN,A,157822,216.239.38.10 \
+	ns2.google.com,IN,A,157822,216.239.34.10
+[73] 2016-10-20 15:24:06.339145 [#6 dns.pcap-dist 4095] \
+	[172.17.0.10].58176 [8.8.8.8].53  \
+	dns QUERY,NOERROR,25433,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:06.340820 [#7 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].58176  \
+	dns QUERY,NOERROR,25433,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72059,dfw06s47-in-f206.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72059,dfw06s47-in-f14.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71542,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71542,ns1.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71542,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71542,ns2.google.com \
+	4 ns1.google.com,IN,A,331816,216.239.32.10 \
+	ns3.google.com,IN,A,157814,216.239.36.10 \
+	ns4.google.com,IN,A,157814,216.239.38.10 \
+	ns2.google.com,IN,A,157814,216.239.34.10
+[73] 2016-10-20 15:24:07.353123 [#8 dns.pcap-dist 4095] \
+	[172.17.0.10].34607 [8.8.8.8].53  \
+	dns QUERY,NOERROR,8470,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:07.354682 [#9 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].34607  \
+	dns QUERY,NOERROR,8470,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72058,dfw06s47-in-f14.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72058,dfw06s47-in-f206.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71541,ns1.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71541,ns2.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71541,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71541,ns3.google.com \
+	4 ns1.google.com,IN,A,331815,216.239.32.10 \
+	ns3.google.com,IN,A,157813,216.239.36.10 \
+	ns4.google.com,IN,A,157813,216.239.38.10 \
+	ns2.google.com,IN,A,157813,216.239.34.10
+[73] 2016-10-20 15:24:08.368516 [#10 dns.pcap-dist 4095] \
+	[172.17.0.10].37149 [8.8.8.8].53  \
+	dns QUERY,NOERROR,44985,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:08.370119 [#11 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].37149  \
+	dns QUERY,NOERROR,44985,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72057,dfw06s47-in-f206.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72057,dfw06s47-in-f14.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71540,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71540,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71540,ns1.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71540,ns2.google.com \
+	4 ns1.google.com,IN,A,331814,216.239.32.10 \
+	ns3.google.com,IN,A,157812,216.239.36.10 \
+	ns4.google.com,IN,A,157812,216.239.38.10 \
+	ns2.google.com,IN,A,157812,216.239.34.10
+[73] 2016-10-20 15:24:09.384057 [#12 dns.pcap-dist 4095] \
+	[172.17.0.10].52368 [8.8.8.8].53  \
+	dns QUERY,NOERROR,22980,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:09.385463 [#13 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].52368  \
+	dns QUERY,NOERROR,22980,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72056,dfw06s47-in-f14.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72056,dfw06s47-in-f206.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71539,ns2.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71539,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71539,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71539,ns1.google.com \
+	4 ns1.google.com,IN,A,331813,216.239.32.10 \
+	ns3.google.com,IN,A,157811,216.239.36.10 \
+	ns4.google.com,IN,A,157811,216.239.38.10 \
+	ns2.google.com,IN,A,157811,216.239.34.10
+[73] 2016-10-20 15:24:10.398099 [#14 dns.pcap-dist 4095] \
+	[172.17.0.10].34426 [8.8.8.8].53  \
+	dns QUERY,NOERROR,25431,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:10.400317 [#15 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].34426  \
+	dns QUERY,NOERROR,25431,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72055,dfw06s47-in-f206.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72055,dfw06s47-in-f14.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71538,ns1.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71538,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71538,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71538,ns2.google.com \
+	4 ns1.google.com,IN,A,331812,216.239.32.10 \
+	ns3.google.com,IN,A,157810,216.239.36.10 \
+	ns4.google.com,IN,A,157810,216.239.38.10 \
+	ns2.google.com,IN,A,157810,216.239.34.10
+[73] 2016-10-20 15:24:11.412133 [#16 dns.pcap-dist 4095] \
+	[172.17.0.10].51181 [8.8.8.8].53  \
+	dns QUERY,NOERROR,47411,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:11.413370 [#17 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].51181  \
+	dns QUERY,NOERROR,47411,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72054,dfw06s47-in-f14.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72054,dfw06s47-in-f206.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71537,ns2.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71537,ns1.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71537,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71537,ns4.google.com \
+	4 ns1.google.com,IN,A,331811,216.239.32.10 \
+	ns3.google.com,IN,A,157809,216.239.36.10 \
+	ns4.google.com,IN,A,157809,216.239.38.10 \
+	ns2.google.com,IN,A,157809,216.239.34.10
+[73] 2016-10-20 15:24:18.452451 [#18 dns.pcap-dist 4095] \
+	[172.17.0.10].40224 [8.8.8.8].53  \
+	dns QUERY,NOERROR,60808,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:18.454030 [#19 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].40224  \
+	dns QUERY,NOERROR,60808,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72047,dfw06s47-in-f206.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72047,dfw06s47-in-f14.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71530,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71530,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71530,ns2.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71530,ns1.google.com \
+	4 ns1.google.com,IN,A,331804,216.239.32.10 \
+	ns3.google.com,IN,A,157802,216.239.36.10 \
+	ns4.google.com,IN,A,157802,216.239.38.10 \
+	ns2.google.com,IN,A,157802,216.239.34.10
+[73] 2016-10-20 15:24:19.467324 [#20 dns.pcap-dist 4095] \
+	[172.17.0.10].60457 [8.8.8.8].53  \
+	dns QUERY,NOERROR,25543,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:19.468895 [#21 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].60457  \
+	dns QUERY,NOERROR,25543,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72046,dfw06s47-in-f14.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72046,dfw06s47-in-f206.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71529,ns2.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71529,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71529,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71529,ns1.google.com \
+	4 ns1.google.com,IN,A,331803,216.239.32.10 \
+	ns3.google.com,IN,A,157801,216.239.36.10 \
+	ns4.google.com,IN,A,157801,216.239.38.10 \
+	ns2.google.com,IN,A,157801,216.239.34.10
+[73] 2016-10-20 15:24:20.482188 [#22 dns.pcap-dist 4095] \
+	[172.17.0.10].56022 [8.8.8.8].53  \
+	dns QUERY,NOERROR,25911,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:20.483927 [#23 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].56022  \
+	dns QUERY,NOERROR,25911,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72045,dfw06s47-in-f206.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72045,dfw06s47-in-f14.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71528,ns1.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71528,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71528,ns2.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71528,ns3.google.com \
+	4 ns1.google.com,IN,A,331802,216.239.32.10 \
+	ns3.google.com,IN,A,157800,216.239.36.10 \
+	ns4.google.com,IN,A,157800,216.239.38.10 \
+	ns2.google.com,IN,A,157800,216.239.34.10
+[73] 2016-10-20 15:24:21.495324 [#24 dns.pcap-dist 4095] \
+	[172.17.0.10].42978 [8.8.8.8].53  \
+	dns QUERY,NOERROR,37698,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:21.496815 [#25 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].42978  \
+	dns QUERY,NOERROR,37698,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72044,dfw06s47-in-f14.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72044,dfw06s47-in-f206.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71527,ns1.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71527,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71527,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71527,ns2.google.com \
+	4 ns1.google.com,IN,A,331801,216.239.32.10 \
+	ns3.google.com,IN,A,157799,216.239.36.10 \
+	ns4.google.com,IN,A,157799,216.239.38.10 \
+	ns2.google.com,IN,A,157799,216.239.34.10
+[73] 2016-10-20 15:24:22.510176 [#26 dns.pcap-dist 4095] \
+	[172.17.0.10].50599 [8.8.8.8].53  \
+	dns QUERY,NOERROR,32142,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:22.511746 [#27 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].50599  \
+	dns QUERY,NOERROR,32142,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72043,dfw06s47-in-f206.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72043,dfw06s47-in-f14.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71526,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71526,ns1.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71526,ns2.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71526,ns4.google.com \
+	4 ns1.google.com,IN,A,331800,216.239.32.10 \
+	ns3.google.com,IN,A,157798,216.239.36.10 \
+	ns4.google.com,IN,A,157798,216.239.38.10 \
+	ns2.google.com,IN,A,157798,216.239.34.10
+[73] 2016-10-20 15:24:23.527449 [#28 dns.pcap-dist 4095] \
+	[172.17.0.10].60063 [8.8.8.8].53  \
+	dns QUERY,NOERROR,18886,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:23.529385 [#29 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].60063  \
+	dns QUERY,NOERROR,18886,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72042,dfw06s47-in-f14.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72042,dfw06s47-in-f206.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71525,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71525,ns1.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71525,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71525,ns2.google.com \
+	4 ns1.google.com,IN,A,331799,216.239.32.10 \
+	ns3.google.com,IN,A,157797,216.239.36.10 \
+	ns4.google.com,IN,A,157797,216.239.38.10 \
+	ns2.google.com,IN,A,157797,216.239.34.10
+[73] 2016-10-20 15:24:24.544538 [#30 dns.pcap-dist 4095] \
+	[172.17.0.10].60469 [8.8.8.8].53  \
+	dns QUERY,NOERROR,33139,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:24.546172 [#31 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].60469  \
+	dns QUERY,NOERROR,33139,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72041,dfw06s47-in-f206.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72041,dfw06s47-in-f14.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71524,ns2.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71524,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71524,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71524,ns1.google.com \
+	4 ns1.google.com,IN,A,331798,216.239.32.10 \
+	ns3.google.com,IN,A,157796,216.239.36.10 \
+	ns4.google.com,IN,A,157796,216.239.38.10 \
+	ns2.google.com,IN,A,157796,216.239.34.10
+[73] 2016-10-20 15:24:25.562608 [#32 dns.pcap-dist 4095] \
+	[172.17.0.10].33507 [8.8.8.8].53  \
+	dns QUERY,NOERROR,59258,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:25.564509 [#33 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].33507  \
+	dns QUERY,NOERROR,59258,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72040,dfw06s47-in-f14.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72040,dfw06s47-in-f206.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71523,ns1.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71523,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71523,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71523,ns2.google.com \
+	4 ns1.google.com,IN,A,331797,216.239.32.10 \
+	ns3.google.com,IN,A,157795,216.239.36.10 \
+	ns4.google.com,IN,A,157795,216.239.38.10 \
+	ns2.google.com,IN,A,157795,216.239.34.10
+-- only PTR
+[73] 2016-10-20 15:23:01.082865 [#0 dns.pcap-dist 4095] \
+	[172.17.0.10].57822 [8.8.8.8].53  \
+	dns QUERY,NOERROR,35665,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:23:01.084107 [#1 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].57822  \
+	dns QUERY,NOERROR,35665,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72125,dfw06s47-in-f14.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72125,dfw06s47-in-f206.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71608,ns2.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71608,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71608,ns1.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71608,ns4.google.com \
+	4 ns1.google.com,IN,A,331882,216.239.32.10 \
+	ns3.google.com,IN,A,157880,216.239.36.10 \
+	ns4.google.com,IN,A,157880,216.239.38.10 \
+	ns2.google.com,IN,A,157880,216.239.34.10
+[73] 2016-10-20 15:23:10.328324 [#2 dns.pcap-dist 4095] \
+	[172.17.0.10].48658 [8.8.8.8].53  \
+	dns QUERY,NOERROR,18718,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:23:10.329572 [#3 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].48658  \
+	dns QUERY,NOERROR,18718,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72115,dfw06s47-in-f206.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72115,dfw06s47-in-f14.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71598,ns2.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71598,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71598,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71598,ns1.google.com \
+	4 ns1.google.com,IN,A,331872,216.239.32.10 \
+	ns3.google.com,IN,A,157870,216.239.36.10 \
+	ns4.google.com,IN,A,157870,216.239.38.10 \
+	ns2.google.com,IN,A,157870,216.239.34.10
+[73] 2016-10-20 15:23:59.090911 [#4 dns.pcap-dist 4095] \
+	[172.17.0.10].33916 [8.8.8.8].53  \
+	dns QUERY,NOERROR,45248,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:23:59.092204 [#5 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].33916  \
+	dns QUERY,NOERROR,45248,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72067,dfw06s47-in-f14.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72067,dfw06s47-in-f206.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71550,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71550,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71550,ns2.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71550,ns1.google.com \
+	4 ns1.google.com,IN,A,331824,216.239.32.10 \
+	ns3.google.com,IN,A,157822,216.239.36.10 \
+	ns4.google.com,IN,A,157822,216.239.38.10 \
+	ns2.google.com,IN,A,157822,216.239.34.10
+[73] 2016-10-20 15:24:06.339145 [#6 dns.pcap-dist 4095] \
+	[172.17.0.10].58176 [8.8.8.8].53  \
+	dns QUERY,NOERROR,25433,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:06.340820 [#7 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].58176  \
+	dns QUERY,NOERROR,25433,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72059,dfw06s47-in-f206.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72059,dfw06s47-in-f14.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71542,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71542,ns1.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71542,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71542,ns2.google.com \
+	4 ns1.google.com,IN,A,331816,216.239.32.10 \
+	ns3.google.com,IN,A,157814,216.239.36.10 \
+	ns4.google.com,IN,A,157814,216.239.38.10 \
+	ns2.google.com,IN,A,157814,216.239.34.10
+[73] 2016-10-20 15:24:07.353123 [#8 dns.pcap-dist 4095] \
+	[172.17.0.10].34607 [8.8.8.8].53  \
+	dns QUERY,NOERROR,8470,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:07.354682 [#9 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].34607  \
+	dns QUERY,NOERROR,8470,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72058,dfw06s47-in-f14.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72058,dfw06s47-in-f206.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71541,ns1.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71541,ns2.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71541,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71541,ns3.google.com \
+	4 ns1.google.com,IN,A,331815,216.239.32.10 \
+	ns3.google.com,IN,A,157813,216.239.36.10 \
+	ns4.google.com,IN,A,157813,216.239.38.10 \
+	ns2.google.com,IN,A,157813,216.239.34.10
+[73] 2016-10-20 15:24:08.368516 [#10 dns.pcap-dist 4095] \
+	[172.17.0.10].37149 [8.8.8.8].53  \
+	dns QUERY,NOERROR,44985,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:08.370119 [#11 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].37149  \
+	dns QUERY,NOERROR,44985,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72057,dfw06s47-in-f206.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72057,dfw06s47-in-f14.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71540,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71540,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71540,ns1.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71540,ns2.google.com \
+	4 ns1.google.com,IN,A,331814,216.239.32.10 \
+	ns3.google.com,IN,A,157812,216.239.36.10 \
+	ns4.google.com,IN,A,157812,216.239.38.10 \
+	ns2.google.com,IN,A,157812,216.239.34.10
+[73] 2016-10-20 15:24:09.384057 [#12 dns.pcap-dist 4095] \
+	[172.17.0.10].52368 [8.8.8.8].53  \
+	dns QUERY,NOERROR,22980,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:09.385463 [#13 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].52368  \
+	dns QUERY,NOERROR,22980,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72056,dfw06s47-in-f14.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72056,dfw06s47-in-f206.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71539,ns2.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71539,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71539,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71539,ns1.google.com \
+	4 ns1.google.com,IN,A,331813,216.239.32.10 \
+	ns3.google.com,IN,A,157811,216.239.36.10 \
+	ns4.google.com,IN,A,157811,216.239.38.10 \
+	ns2.google.com,IN,A,157811,216.239.34.10
+[73] 2016-10-20 15:24:10.398099 [#14 dns.pcap-dist 4095] \
+	[172.17.0.10].34426 [8.8.8.8].53  \
+	dns QUERY,NOERROR,25431,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:10.400317 [#15 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].34426  \
+	dns QUERY,NOERROR,25431,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72055,dfw06s47-in-f206.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72055,dfw06s47-in-f14.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71538,ns1.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71538,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71538,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71538,ns2.google.com \
+	4 ns1.google.com,IN,A,331812,216.239.32.10 \
+	ns3.google.com,IN,A,157810,216.239.36.10 \
+	ns4.google.com,IN,A,157810,216.239.38.10 \
+	ns2.google.com,IN,A,157810,216.239.34.10
+[73] 2016-10-20 15:24:11.412133 [#16 dns.pcap-dist 4095] \
+	[172.17.0.10].51181 [8.8.8.8].53  \
+	dns QUERY,NOERROR,47411,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:11.413370 [#17 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].51181  \
+	dns QUERY,NOERROR,47411,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72054,dfw06s47-in-f14.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72054,dfw06s47-in-f206.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71537,ns2.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71537,ns1.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71537,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71537,ns4.google.com \
+	4 ns1.google.com,IN,A,331811,216.239.32.10 \
+	ns3.google.com,IN,A,157809,216.239.36.10 \
+	ns4.google.com,IN,A,157809,216.239.38.10 \
+	ns2.google.com,IN,A,157809,216.239.34.10
+[73] 2016-10-20 15:24:18.452451 [#18 dns.pcap-dist 4095] \
+	[172.17.0.10].40224 [8.8.8.8].53  \
+	dns QUERY,NOERROR,60808,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:18.454030 [#19 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].40224  \
+	dns QUERY,NOERROR,60808,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72047,dfw06s47-in-f206.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72047,dfw06s47-in-f14.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71530,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71530,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71530,ns2.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71530,ns1.google.com \
+	4 ns1.google.com,IN,A,331804,216.239.32.10 \
+	ns3.google.com,IN,A,157802,216.239.36.10 \
+	ns4.google.com,IN,A,157802,216.239.38.10 \
+	ns2.google.com,IN,A,157802,216.239.34.10
+[73] 2016-10-20 15:24:19.467324 [#20 dns.pcap-dist 4095] \
+	[172.17.0.10].60457 [8.8.8.8].53  \
+	dns QUERY,NOERROR,25543,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:19.468895 [#21 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].60457  \
+	dns QUERY,NOERROR,25543,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72046,dfw06s47-in-f14.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72046,dfw06s47-in-f206.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71529,ns2.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71529,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71529,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71529,ns1.google.com \
+	4 ns1.google.com,IN,A,331803,216.239.32.10 \
+	ns3.google.com,IN,A,157801,216.239.36.10 \
+	ns4.google.com,IN,A,157801,216.239.38.10 \
+	ns2.google.com,IN,A,157801,216.239.34.10
+[73] 2016-10-20 15:24:20.482188 [#22 dns.pcap-dist 4095] \
+	[172.17.0.10].56022 [8.8.8.8].53  \
+	dns QUERY,NOERROR,25911,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:20.483927 [#23 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].56022  \
+	dns QUERY,NOERROR,25911,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72045,dfw06s47-in-f206.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72045,dfw06s47-in-f14.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71528,ns1.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71528,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71528,ns2.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71528,ns3.google.com \
+	4 ns1.google.com,IN,A,331802,216.239.32.10 \
+	ns3.google.com,IN,A,157800,216.239.36.10 \
+	ns4.google.com,IN,A,157800,216.239.38.10 \
+	ns2.google.com,IN,A,157800,216.239.34.10
+[73] 2016-10-20 15:24:21.495324 [#24 dns.pcap-dist 4095] \
+	[172.17.0.10].42978 [8.8.8.8].53  \
+	dns QUERY,NOERROR,37698,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:21.496815 [#25 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].42978  \
+	dns QUERY,NOERROR,37698,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72044,dfw06s47-in-f14.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72044,dfw06s47-in-f206.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71527,ns1.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71527,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71527,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71527,ns2.google.com \
+	4 ns1.google.com,IN,A,331801,216.239.32.10 \
+	ns3.google.com,IN,A,157799,216.239.36.10 \
+	ns4.google.com,IN,A,157799,216.239.38.10 \
+	ns2.google.com,IN,A,157799,216.239.34.10
+[73] 2016-10-20 15:24:22.510176 [#26 dns.pcap-dist 4095] \
+	[172.17.0.10].50599 [8.8.8.8].53  \
+	dns QUERY,NOERROR,32142,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:22.511746 [#27 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].50599  \
+	dns QUERY,NOERROR,32142,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72043,dfw06s47-in-f206.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72043,dfw06s47-in-f14.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71526,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71526,ns1.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71526,ns2.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71526,ns4.google.com \
+	4 ns1.google.com,IN,A,331800,216.239.32.10 \
+	ns3.google.com,IN,A,157798,216.239.36.10 \
+	ns4.google.com,IN,A,157798,216.239.38.10 \
+	ns2.google.com,IN,A,157798,216.239.34.10
+[73] 2016-10-20 15:24:23.527449 [#28 dns.pcap-dist 4095] \
+	[172.17.0.10].60063 [8.8.8.8].53  \
+	dns QUERY,NOERROR,18886,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:23.529385 [#29 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].60063  \
+	dns QUERY,NOERROR,18886,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72042,dfw06s47-in-f14.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72042,dfw06s47-in-f206.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71525,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71525,ns1.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71525,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71525,ns2.google.com \
+	4 ns1.google.com,IN,A,331799,216.239.32.10 \
+	ns3.google.com,IN,A,157797,216.239.36.10 \
+	ns4.google.com,IN,A,157797,216.239.38.10 \
+	ns2.google.com,IN,A,157797,216.239.34.10
+[73] 2016-10-20 15:24:24.544538 [#30 dns.pcap-dist 4095] \
+	[172.17.0.10].60469 [8.8.8.8].53  \
+	dns QUERY,NOERROR,33139,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:24.546172 [#31 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].60469  \
+	dns QUERY,NOERROR,33139,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72041,dfw06s47-in-f206.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72041,dfw06s47-in-f14.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71524,ns2.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71524,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71524,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71524,ns1.google.com \
+	4 ns1.google.com,IN,A,331798,216.239.32.10 \
+	ns3.google.com,IN,A,157796,216.239.36.10 \
+	ns4.google.com,IN,A,157796,216.239.38.10 \
+	ns2.google.com,IN,A,157796,216.239.34.10
+[73] 2016-10-20 15:24:25.562608 [#32 dns.pcap-dist 4095] \
+	[172.17.0.10].33507 [8.8.8.8].53  \
+	dns QUERY,NOERROR,59258,rd \
+	1 206.218.58.216.in-addr.arpa,IN,PTR 0 0 0
+[289] 2016-10-20 15:24:25.564509 [#33 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].33507  \
+	dns QUERY,NOERROR,59258,qr|rd|ra \
+	1 206.218.58.216.in-addr.arpa,IN,PTR \
+	2 206.218.58.216.in-addr.arpa,IN,PTR,72040,dfw06s47-in-f14.1e100.net \
+	206.218.58.216.in-addr.arpa,IN,PTR,72040,dfw06s47-in-f206.1e100.net \
+	4 218.58.216.in-addr.arpa,IN,NS,71523,ns1.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71523,ns4.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71523,ns3.google.com \
+	218.58.216.in-addr.arpa,IN,NS,71523,ns2.google.com \
+	4 ns1.google.com,IN,A,331797,216.239.32.10 \
+	ns3.google.com,IN,A,157795,216.239.36.10 \
+	ns4.google.com,IN,A,157795,216.239.38.10 \
+	ns2.google.com,IN,A,157795,216.239.34.10
+-- not PTR
+[56] 2016-10-20 15:23:01.075993 [#0 dns.pcap-dist 4095] \
+	[172.17.0.10].53199 [8.8.8.8].53  \
+	dns QUERY,NOERROR,59311,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:23:01.077982 [#1 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].53199  \
+	dns QUERY,NOERROR,59311,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,44,216.58.218.206 \
+	4 google.com,IN,NS,157880,ns4.google.com \
+	google.com,IN,NS,157880,ns3.google.com \
+	google.com,IN,NS,157880,ns1.google.com \
+	google.com,IN,NS,157880,ns2.google.com \
+	4 ns2.google.com,IN,A,157880,216.239.34.10 \
+	ns1.google.com,IN,A,331882,216.239.32.10 \
+	ns3.google.com,IN,A,157880,216.239.36.10 \
+	ns4.google.com,IN,A,157880,216.239.38.10
+[56] 2016-10-20 15:23:01.087291 [#2 dns.pcap-dist 4095] \
+	[172.17.0.10].40043 [8.8.8.8].53  \
+	dns QUERY,NOERROR,5337,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:23:01.088733 [#3 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].40043  \
+	dns QUERY,NOERROR,5337,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,44,216.58.218.206 \
+	4 google.com,IN,NS,157880,ns1.google.com \
+	google.com,IN,NS,157880,ns2.google.com \
+	google.com,IN,NS,157880,ns3.google.com \
+	google.com,IN,NS,157880,ns4.google.com \
+	4 ns2.google.com,IN,A,157880,216.239.34.10 \
+	ns1.google.com,IN,A,331882,216.239.32.10 \
+	ns3.google.com,IN,A,157880,216.239.36.10 \
+	ns4.google.com,IN,A,157880,216.239.38.10
+[56] 2016-10-20 15:23:10.322117 [#4 dns.pcap-dist 4095] \
+	[172.17.0.10].37953 [8.8.8.8].53  \
+	dns QUERY,NOERROR,22982,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:23:10.323399 [#5 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].37953  \
+	dns QUERY,NOERROR,22982,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,34,216.58.218.206 \
+	4 google.com,IN,NS,157870,ns4.google.com \
+	google.com,IN,NS,157870,ns1.google.com \
+	google.com,IN,NS,157870,ns2.google.com \
+	google.com,IN,NS,157870,ns3.google.com \
+	4 ns2.google.com,IN,A,157870,216.239.34.10 \
+	ns1.google.com,IN,A,331872,216.239.32.10 \
+	ns3.google.com,IN,A,157870,216.239.36.10 \
+	ns4.google.com,IN,A,157870,216.239.38.10
+[56] 2016-10-20 15:23:52.860937 [#6 dns.pcap-dist 4095] \
+	[172.17.0.10].40953 [8.8.8.8].53  \
+	dns QUERY,NOERROR,22531,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:23:52.863771 [#7 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].40953  \
+	dns QUERY,NOERROR,22531,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,297,216.58.218.206 \
+	4 google.com,IN,NS,157828,ns2.google.com \
+	google.com,IN,NS,157828,ns4.google.com \
+	google.com,IN,NS,157828,ns1.google.com \
+	google.com,IN,NS,157828,ns3.google.com \
+	4 ns2.google.com,IN,A,157828,216.239.34.10 \
+	ns1.google.com,IN,A,331830,216.239.32.10 \
+	ns3.google.com,IN,A,157828,216.239.36.10 \
+	ns4.google.com,IN,A,157828,216.239.38.10
+[56] 2016-10-20 15:23:59.083869 [#8 dns.pcap-dist 4095] \
+	[172.17.0.10].45174 [8.8.8.8].53  \
+	dns QUERY,NOERROR,58510,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:23:59.086104 [#9 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].45174  \
+	dns QUERY,NOERROR,58510,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,291,216.58.218.206 \
+	4 google.com,IN,NS,157822,ns2.google.com \
+	google.com,IN,NS,157822,ns3.google.com \
+	google.com,IN,NS,157822,ns1.google.com \
+	google.com,IN,NS,157822,ns4.google.com \
+	4 ns2.google.com,IN,A,157822,216.239.34.10 \
+	ns1.google.com,IN,A,331824,216.239.32.10 \
+	ns3.google.com,IN,A,157822,216.239.36.10 \
+	ns4.google.com,IN,A,157822,216.239.38.10
+[56] 2016-10-20 15:24:04.323868 [#10 dns.pcap-dist 4095] \
+	[172.17.0.10].43559 [8.8.8.8].53  \
+	dns QUERY,NOERROR,49483,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:04.325597 [#11 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].43559  \
+	dns QUERY,NOERROR,49483,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,285,216.58.218.206 \
+	4 google.com,IN,NS,157816,ns4.google.com \
+	google.com,IN,NS,157816,ns3.google.com \
+	google.com,IN,NS,157816,ns1.google.com \
+	google.com,IN,NS,157816,ns2.google.com \
+	4 ns2.google.com,IN,A,157816,216.239.34.10 \
+	ns1.google.com,IN,A,331818,216.239.32.10 \
+	ns3.google.com,IN,A,157816,216.239.36.10 \
+	ns4.google.com,IN,A,157816,216.239.38.10
+[56] 2016-10-20 15:24:06.332239 [#12 dns.pcap-dist 4095] \
+	[172.17.0.10].54859 [8.8.8.8].53  \
+	dns QUERY,NOERROR,31669,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:06.333743 [#13 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].54859  \
+	dns QUERY,NOERROR,31669,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,283,216.58.218.206 \
+	4 google.com,IN,NS,157814,ns2.google.com \
+	google.com,IN,NS,157814,ns1.google.com \
+	google.com,IN,NS,157814,ns4.google.com \
+	google.com,IN,NS,157814,ns3.google.com \
+	4 ns2.google.com,IN,A,157814,216.239.34.10 \
+	ns1.google.com,IN,A,331816,216.239.32.10 \
+	ns3.google.com,IN,A,157814,216.239.36.10 \
+	ns4.google.com,IN,A,157814,216.239.38.10
+[56] 2016-10-20 15:24:07.346429 [#14 dns.pcap-dist 4095] \
+	[172.17.0.10].41266 [8.8.8.8].53  \
+	dns QUERY,NOERROR,63798,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:07.348160 [#15 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].41266  \
+	dns QUERY,NOERROR,63798,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,282,216.58.218.206 \
+	4 google.com,IN,NS,157813,ns4.google.com \
+	google.com,IN,NS,157813,ns1.google.com \
+	google.com,IN,NS,157813,ns3.google.com \
+	google.com,IN,NS,157813,ns2.google.com \
+	4 ns2.google.com,IN,A,157813,216.239.34.10 \
+	ns1.google.com,IN,A,331815,216.239.32.10 \
+	ns3.google.com,IN,A,157813,216.239.36.10 \
+	ns4.google.com,IN,A,157813,216.239.38.10
+[56] 2016-10-20 15:24:08.360528 [#16 dns.pcap-dist 4095] \
+	[172.17.0.10].60437 [8.8.8.8].53  \
+	dns QUERY,NOERROR,60258,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:08.362206 [#17 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].60437  \
+	dns QUERY,NOERROR,60258,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,281,216.58.218.206 \
+	4 google.com,IN,NS,157812,ns3.google.com \
+	google.com,IN,NS,157812,ns2.google.com \
+	google.com,IN,NS,157812,ns4.google.com \
+	google.com,IN,NS,157812,ns1.google.com \
+	4 ns2.google.com,IN,A,157812,216.239.34.10 \
+	ns1.google.com,IN,A,331814,216.239.32.10 \
+	ns3.google.com,IN,A,157812,216.239.36.10 \
+	ns4.google.com,IN,A,157812,216.239.38.10
+[56] 2016-10-20 15:24:09.375942 [#18 dns.pcap-dist 4095] \
+	[172.17.0.10].53820 [8.8.8.8].53  \
+	dns QUERY,NOERROR,45512,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:09.378425 [#19 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].53820  \
+	dns QUERY,NOERROR,45512,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,280,216.58.218.206 \
+	4 google.com,IN,NS,157811,ns3.google.com \
+	google.com,IN,NS,157811,ns4.google.com \
+	google.com,IN,NS,157811,ns1.google.com \
+	google.com,IN,NS,157811,ns2.google.com \
+	4 ns2.google.com,IN,A,157811,216.239.34.10 \
+	ns1.google.com,IN,A,331813,216.239.32.10 \
+	ns3.google.com,IN,A,157811,216.239.36.10 \
+	ns4.google.com,IN,A,157811,216.239.38.10
+[56] 2016-10-20 15:24:10.391358 [#20 dns.pcap-dist 4095] \
+	[172.17.0.10].47637 [8.8.8.8].53  \
+	dns QUERY,NOERROR,1834,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:10.392886 [#21 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].47637  \
+	dns QUERY,NOERROR,1834,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,279,216.58.218.206 \
+	4 google.com,IN,NS,157810,ns1.google.com \
+	google.com,IN,NS,157810,ns2.google.com \
+	google.com,IN,NS,157810,ns4.google.com \
+	google.com,IN,NS,157810,ns3.google.com \
+	4 ns2.google.com,IN,A,157810,216.239.34.10 \
+	ns1.google.com,IN,A,331812,216.239.32.10 \
+	ns3.google.com,IN,A,157810,216.239.36.10 \
+	ns4.google.com,IN,A,157810,216.239.38.10
+[56] 2016-10-20 15:24:11.406297 [#22 dns.pcap-dist 4095] \
+	[172.17.0.10].41059 [8.8.8.8].53  \
+	dns QUERY,NOERROR,48432,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:11.407460 [#23 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].41059  \
+	dns QUERY,NOERROR,48432,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,278,216.58.218.206 \
+	4 google.com,IN,NS,157809,ns3.google.com \
+	google.com,IN,NS,157809,ns4.google.com \
+	google.com,IN,NS,157809,ns2.google.com \
+	google.com,IN,NS,157809,ns1.google.com \
+	4 ns2.google.com,IN,A,157809,216.239.34.10 \
+	ns1.google.com,IN,A,331811,216.239.32.10 \
+	ns3.google.com,IN,A,157809,216.239.36.10 \
+	ns4.google.com,IN,A,157809,216.239.38.10
+[56] 2016-10-20 15:24:12.419936 [#24 dns.pcap-dist 4095] \
+	[172.17.0.10].32976 [8.8.8.8].53  \
+	dns QUERY,NOERROR,12038,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:12.421228 [#25 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].32976  \
+	dns QUERY,NOERROR,12038,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,277,216.58.218.206 \
+	4 google.com,IN,NS,157808,ns2.google.com \
+	google.com,IN,NS,157808,ns3.google.com \
+	google.com,IN,NS,157808,ns1.google.com \
+	google.com,IN,NS,157808,ns4.google.com \
+	4 ns2.google.com,IN,A,157808,216.239.34.10 \
+	ns1.google.com,IN,A,331810,216.239.32.10 \
+	ns3.google.com,IN,A,157808,216.239.36.10 \
+	ns4.google.com,IN,A,157808,216.239.38.10
+[56] 2016-10-20 15:24:14.428524 [#26 dns.pcap-dist 4095] \
+	[172.17.0.10].53467 [8.8.8.8].53  \
+	dns QUERY,NOERROR,11614,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:14.429863 [#27 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].53467  \
+	dns QUERY,NOERROR,11614,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,275,216.58.218.206 \
+	4 google.com,IN,NS,157806,ns3.google.com \
+	google.com,IN,NS,157806,ns1.google.com \
+	google.com,IN,NS,157806,ns4.google.com \
+	google.com,IN,NS,157806,ns2.google.com \
+	4 ns2.google.com,IN,A,157806,216.239.34.10 \
+	ns1.google.com,IN,A,331808,216.239.32.10 \
+	ns3.google.com,IN,A,157806,216.239.36.10 \
+	ns4.google.com,IN,A,157806,216.239.38.10
+[56] 2016-10-20 15:24:16.435733 [#28 dns.pcap-dist 4095] \
+	[172.17.0.10].41532 [8.8.8.8].53  \
+	dns QUERY,NOERROR,59173,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:16.437471 [#29 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].41532  \
+	dns QUERY,NOERROR,59173,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,273,216.58.218.206 \
+	4 google.com,IN,NS,157804,ns1.google.com \
+	google.com,IN,NS,157804,ns3.google.com \
+	google.com,IN,NS,157804,ns2.google.com \
+	google.com,IN,NS,157804,ns4.google.com \
+	4 ns2.google.com,IN,A,157804,216.239.34.10 \
+	ns1.google.com,IN,A,331806,216.239.32.10 \
+	ns3.google.com,IN,A,157804,216.239.36.10 \
+	ns4.google.com,IN,A,157804,216.239.38.10
+[56] 2016-10-20 15:24:18.445519 [#30 dns.pcap-dist 4095] \
+	[172.17.0.10].44982 [8.8.8.8].53  \
+	dns QUERY,NOERROR,45535,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:18.446775 [#31 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].44982  \
+	dns QUERY,NOERROR,45535,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,271,216.58.218.206 \
+	4 google.com,IN,NS,157802,ns4.google.com \
+	google.com,IN,NS,157802,ns2.google.com \
+	google.com,IN,NS,157802,ns1.google.com \
+	google.com,IN,NS,157802,ns3.google.com \
+	4 ns2.google.com,IN,A,157802,216.239.34.10 \
+	ns1.google.com,IN,A,331804,216.239.32.10 \
+	ns3.google.com,IN,A,157802,216.239.36.10 \
+	ns4.google.com,IN,A,157802,216.239.38.10
+[56] 2016-10-20 15:24:19.460087 [#32 dns.pcap-dist 4095] \
+	[172.17.0.10].45658 [8.8.8.8].53  \
+	dns QUERY,NOERROR,64325,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:19.462224 [#33 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].45658  \
+	dns QUERY,NOERROR,64325,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,270,216.58.218.206 \
+	4 google.com,IN,NS,157801,ns1.google.com \
+	google.com,IN,NS,157801,ns3.google.com \
+	google.com,IN,NS,157801,ns4.google.com \
+	google.com,IN,NS,157801,ns2.google.com \
+	4 ns2.google.com,IN,A,157801,216.239.34.10 \
+	ns1.google.com,IN,A,331803,216.239.32.10 \
+	ns3.google.com,IN,A,157801,216.239.36.10 \
+	ns4.google.com,IN,A,157801,216.239.38.10
+[56] 2016-10-20 15:24:20.475086 [#34 dns.pcap-dist 4095] \
+	[172.17.0.10].59762 [8.8.8.8].53  \
+	dns QUERY,NOERROR,20736,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:20.476841 [#35 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].59762  \
+	dns QUERY,NOERROR,20736,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,269,216.58.218.206 \
+	4 google.com,IN,NS,157800,ns3.google.com \
+	google.com,IN,NS,157800,ns1.google.com \
+	google.com,IN,NS,157800,ns4.google.com \
+	google.com,IN,NS,157800,ns2.google.com \
+	4 ns2.google.com,IN,A,157800,216.239.34.10 \
+	ns1.google.com,IN,A,331802,216.239.32.10 \
+	ns3.google.com,IN,A,157800,216.239.36.10 \
+	ns4.google.com,IN,A,157800,216.239.38.10
+[56] 2016-10-20 15:24:21.489468 [#36 dns.pcap-dist 4095] \
+	[172.17.0.10].37669 [8.8.8.8].53  \
+	dns QUERY,NOERROR,64358,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:21.490573 [#37 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].37669  \
+	dns QUERY,NOERROR,64358,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,268,216.58.218.206 \
+	4 google.com,IN,NS,157799,ns2.google.com \
+	google.com,IN,NS,157799,ns1.google.com \
+	google.com,IN,NS,157799,ns4.google.com \
+	google.com,IN,NS,157799,ns3.google.com \
+	4 ns2.google.com,IN,A,157799,216.239.34.10 \
+	ns1.google.com,IN,A,331801,216.239.32.10 \
+	ns3.google.com,IN,A,157799,216.239.36.10 \
+	ns4.google.com,IN,A,157799,216.239.38.10
+[56] 2016-10-20 15:24:22.502667 [#38 dns.pcap-dist 4095] \
+	[172.17.0.10].49829 [8.8.8.8].53  \
+	dns QUERY,NOERROR,54706,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:22.504738 [#39 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].49829  \
+	dns QUERY,NOERROR,54706,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,267,216.58.218.206 \
+	4 google.com,IN,NS,157798,ns2.google.com \
+	google.com,IN,NS,157798,ns4.google.com \
+	google.com,IN,NS,157798,ns3.google.com \
+	google.com,IN,NS,157798,ns1.google.com \
+	4 ns2.google.com,IN,A,157798,216.239.34.10 \
+	ns1.google.com,IN,A,331800,216.239.32.10 \
+	ns3.google.com,IN,A,157798,216.239.36.10 \
+	ns4.google.com,IN,A,157798,216.239.38.10
+[56] 2016-10-20 15:24:23.520203 [#40 dns.pcap-dist 4095] \
+	[172.17.0.10].44980 [8.8.8.8].53  \
+	dns QUERY,NOERROR,41808,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:23.521976 [#41 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].44980  \
+	dns QUERY,NOERROR,41808,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,266,216.58.218.206 \
+	4 google.com,IN,NS,157797,ns2.google.com \
+	google.com,IN,NS,157797,ns4.google.com \
+	google.com,IN,NS,157797,ns1.google.com \
+	google.com,IN,NS,157797,ns3.google.com \
+	4 ns2.google.com,IN,A,157797,216.239.34.10 \
+	ns1.google.com,IN,A,331799,216.239.32.10 \
+	ns3.google.com,IN,A,157797,216.239.36.10 \
+	ns4.google.com,IN,A,157797,216.239.38.10
+[56] 2016-10-20 15:24:24.537264 [#42 dns.pcap-dist 4095] \
+	[172.17.0.10].42042 [8.8.8.8].53  \
+	dns QUERY,NOERROR,10624,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:24.539398 [#43 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].42042  \
+	dns QUERY,NOERROR,10624,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,265,216.58.218.206 \
+	4 google.com,IN,NS,157796,ns3.google.com \
+	google.com,IN,NS,157796,ns4.google.com \
+	google.com,IN,NS,157796,ns1.google.com \
+	google.com,IN,NS,157796,ns2.google.com \
+	4 ns2.google.com,IN,A,157796,216.239.34.10 \
+	ns1.google.com,IN,A,331798,216.239.32.10 \
+	ns3.google.com,IN,A,157796,216.239.36.10 \
+	ns4.google.com,IN,A,157796,216.239.38.10
+[56] 2016-10-20 15:24:25.554744 [#44 dns.pcap-dist 4095] \
+	[172.17.0.10].45703 [8.8.8.8].53  \
+	dns QUERY,NOERROR,61415,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:25.556513 [#45 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].45703  \
+	dns QUERY,NOERROR,61415,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,264,216.58.218.206 \
+	4 google.com,IN,NS,157795,ns3.google.com \
+	google.com,IN,NS,157795,ns4.google.com \
+	google.com,IN,NS,157795,ns2.google.com \
+	google.com,IN,NS,157795,ns1.google.com \
+	4 ns2.google.com,IN,A,157795,216.239.34.10 \
+	ns1.google.com,IN,A,331797,216.239.32.10 \
+	ns3.google.com,IN,A,157795,216.239.36.10 \
+	ns4.google.com,IN,A,157795,216.239.38.10
+[56] 2016-10-20 15:24:26.572784 [#46 dns.pcap-dist 4095] \
+	[172.17.0.10].46798 [8.8.8.8].53  \
+	dns QUERY,NOERROR,17700,rd \
+	1 google.com,IN,A 0 0 0
+[208] 2016-10-20 15:24:26.574350 [#47 dns.pcap-dist 4095] \
+	[8.8.8.8].53 [172.17.0.10].46798  \
+	dns QUERY,NOERROR,17700,qr|rd|ra \
+	1 google.com,IN,A \
+	1 google.com,IN,A,263,216.58.218.206 \
+	4 google.com,IN,NS,157794,ns1.google.com \
+	google.com,IN,NS,157794,ns4.google.com \
+	google.com,IN,NS,157794,ns3.google.com \
+	google.com,IN,NS,157794,ns2.google.com \
+	4 ns2.google.com,IN,A,157794,216.239.34.10 \
+	ns1.google.com,IN,A,331796,216.239.32.10 \
+	ns3.google.com,IN,A,157794,216.239.36.10 \
+	ns4.google.com,IN,A,157794,216.239.38.10

--- a/src/test/test14.sh
+++ b/src/test/test14.sh
@@ -1,0 +1,25 @@
+#!/bin/sh -xe
+
+echo "-- only 1" >test14.out
+../dnscap -g -q 1 -r dns.pcap-dist 2>>test14.out
+echo "-- not 1" >>test14.out
+../dnscap -g -Q 1 -r dns.pcap-dist 2>>test14.out
+echo "-- only PTR" >>test14.out
+../dnscap -g -q PTR -r dns.pcap-dist 2>>test14.out
+echo "-- not PTR" >>test14.out
+../dnscap -g -Q PTR -r dns.pcap-dist 2>>test14.out
+
+echo "-- only 1" >>test14.out
+../dnscap -g -o use_layers=yes -q 1 -r dns.pcap-dist 2>>test14.out
+echo "-- not 1" >>test14.out
+../dnscap -g -o use_layers=yes -Q 1 -r dns.pcap-dist 2>>test14.out
+echo "-- only PTR" >>test14.out
+../dnscap -g -o use_layers=yes -q PTR -r dns.pcap-dist 2>>test14.out
+echo "-- not PTR" >>test14.out
+../dnscap -g -o use_layers=yes -Q PTR -r dns.pcap-dist 2>>test14.out
+
+mv test14.out test14.out.old
+grep -v "^libgcov profiling error:" test14.out.old > test14.out
+rm test14.out.old
+
+diff test14.out "$srcdir/test14.gold"

--- a/src/test/test2.sh
+++ b/src/test/test2.sh
@@ -3,14 +3,4 @@
 ../dnscap -g -r dns.pcap-dist 2>no-layers.out
 ../dnscap -g -r dns.pcap-dist -o use_layers=yes 2>layers.out
 
-osrel=`uname -s`
-if [ "$osrel" = "OpenBSD" ]; then
-    mv no-layers.out no-layers.out.old
-    grep -v "^dnscap.*WARNING.*symbol.*relink" no-layers.out.old > no-layers.out
-    rm no-layers.out.old
-    mv layers.out layers.out.old
-    grep -v "^dnscap.*WARNING.*symbol.*relink" layers.out.old > layers.out
-    rm layers.out.old
-fi
-
 diff no-layers.out layers.out

--- a/src/test/test3.sh
+++ b/src/test/test3.sh
@@ -5,13 +5,6 @@
 # remove timestamp
 sed -i -e 's%^\(\[[0-9]*\]\)[^\[]*\[%\1 [%g' frags.out
 
-osrel=`uname -s`
-if [ "$osrel" = "OpenBSD" ]; then
-    mv frags.out frags.out.old
-    grep -v "^dnscap.*WARNING.*symbol.*relink" frags.out.old > frags.out
-    rm frags.out.old
-fi
-
 # create gold file
 cp "$srcdir/dns.gold" frags.gold
 sed -i -e 's%^\(\[[0-9]*\]\)[^\[]*\[%\1 [%g' frags.gold

--- a/src/test/test4.sh
+++ b/src/test/test4.sh
@@ -3,14 +3,4 @@
 ../dnscap -g -T -r 1qtcppadd.pcap-dist 2>padding-no-layers.out
 ../dnscap -g -T -r 1qtcppadd.pcap-dist -o use_layers=yes 2>padding-layers.out
 
-osrel=`uname -s`
-if [ "$osrel" = "OpenBSD" ]; then
-    mv padding-no-layers.out padding-no-layers.out.old
-    grep -v "^dnscap.*WARNING.*symbol.*relink" padding-no-layers.out.old > padding-no-layers.out
-    rm padding-no-layers.out.old
-    mv padding-layers.out padding-layers.out.old
-    grep -v "^dnscap.*WARNING.*symbol.*relink" padding-layers.out.old > padding-layers.out
-    rm padding-layers.out.old
-fi
-
 diff padding-no-layers.out padding-layers.out

--- a/src/test/test5.sh
+++ b/src/test/test5.sh
@@ -2,31 +2,19 @@
 
 osrel=`uname -s`
 
-clean_out() {
-    if [ "$osrel" = "OpenBSD" ]; then
-        mv vlan11.out vlan11.out.old
-        grep -v "^dnscap.*WARNING.*symbol.*relink" vlan11.out.old > vlan11.out
-        rm vlan11.out.old
-    fi
-}
-
 ../dnscap -g -r vlan11.pcap-dist 2>vlan11.out
 test -f vlan11.out && ! test -s vlan11.out
 ../dnscap -g -r vlan11.pcap-dist -L 10 2>vlan11.out
 test -f vlan11.out && ! test -s vlan11.out
 ../dnscap -g -r vlan11.pcap-dist -L 4095 2>vlan11.out
-clean_out
 diff vlan11.out "$srcdir/vlan11.gold"
 ../dnscap -g -r vlan11.pcap-dist -L 11 2>vlan11.out
-clean_out
 diff vlan11.out "$srcdir/vlan11.gold"
 ../dnscap -g -r vlan11.pcap-dist -o use_layers=yes 2>vlan11.out
 test -f vlan11.out && ! test -s vlan11.out
 ../dnscap -g -r vlan11.pcap-dist -o use_layers=yes -L 10 2>vlan11.out
 test -f vlan11.out && ! test -s vlan11.out
 ../dnscap -g -r vlan11.pcap-dist -o use_layers=yes -L 4095 2>vlan11.out
-clean_out
 diff vlan11.out "$srcdir/vlan11.gold"
 ../dnscap -g -r vlan11.pcap-dist -o use_layers=yes -L 11 2>vlan11.out
-clean_out
 diff vlan11.out "$srcdir/vlan11.gold"

--- a/src/test/test6.sh
+++ b/src/test/test6.sh
@@ -3,11 +3,4 @@
 ../dnscap -g -r dnspad.pcap-dist 2>dnspad.out
 ../dnscap -o use_layers=yes -g -r dnspad.pcap-dist 2>>dnspad.out
 
-osrel=`uname -s`
-if [ "$osrel" = "OpenBSD" ]; then
-    mv dnspad.out dnspad.out.old
-    grep -v "^dnscap.*WARNING.*symbol.*relink" dnspad.out.old > dnspad.out
-    rm dnspad.out.old
-fi
-
 diff dnspad.out "$srcdir/dnspad.gold"

--- a/src/test/test7.sh
+++ b/src/test/test7.sh
@@ -29,29 +29,5 @@ for what in dnso1tcp.pcap-dist 1qtcpnosyn.pcap-dist do1t-nosyn-1nolen.pcap-dist 
     fi
 done
 
-osrel=`uname -s`
-if [ "$osrel" = "OpenBSD" ]; then
-    mv test7.out test7.out.old
-    grep -v "^dnscap.*WARNING.*symbol.*relink" test7.out.old > test7.out
-    rm test7.out.old
-    mv test7.layer.out test7.layer.out.old
-    grep -v "^dnscap.*WARNING.*symbol.*relink" test7.layer.out.old > test7.layer.out
-    rm test7.layer.out.old
-fi
-
-# TODO: Remove when #133 is fixed
-cat test7.out | \
-  sed 's%,CLASS4096,OPT,%,4096,4096,%' | \
-  sed 's%,CLASS512,OPT,%,512,512,%' | \
-  sed 's%,41,41,0,edns0\[len=0,UDP=4096,%,4096,4096,0,edns0[len=0,UDP=4096,%' | \
-  sed 's%,41,41,0,edns0\[len=0,UDP=512,%,512,512,0,edns0[len=0,UDP=512,%' >test7.new
-mv test7.new test7.out
-cat test7.layer.out | \
-  sed 's%,CLASS4096,OPT,%,4096,4096,%' | \
-  sed 's%,CLASS512,OPT,%,512,512,%' | \
-  sed 's%,41,41,0,edns0\[len=0,UDP=4096,%,4096,4096,0,edns0[len=0,UDP=4096,%' | \
-  sed 's%,41,41,0,edns0\[len=0,UDP=512,%,512,512,0,edns0[len=0,UDP=512,%' >test7.layer.new
-mv test7.layer.new test7.layer.out
-
 diff test7.out "$srcdir/test7.gold"
 diff test7.layer.out "$srcdir/test7.gold"

--- a/src/test/test8.sh
+++ b/src/test/test8.sh
@@ -12,29 +12,5 @@ for what in dnso1tcp-bighole.pcap-dist; do
     ../dnscap -r "$what" -g -T -o reassemble_tcp=yes -o allow_reset_tcpstate=yes -o use_layers=yes 2>>test8.layer.out
 done
 
-osrel=`uname -s`
-if [ "$osrel" = "OpenBSD" ]; then
-    mv test8.out test8.out.old
-    grep -v "^dnscap.*WARNING.*symbol.*relink" test8.out.old > test8.out
-    rm test8.out.old
-    mv test8.layer.out test8.layer.out.old
-    grep -v "^dnscap.*WARNING.*symbol.*relink" test8.layer.out.old > test8.layer.out
-    rm test8.layer.out.old
-fi
-
-# TODO: Remove when #133 is fixed
-cat test8.out | \
-  sed 's%,CLASS4096,OPT,%,4096,4096,%' | \
-  sed 's%,CLASS512,OPT,%,512,512,%' | \
-  sed 's%,41,41,0,edns0\[len=0,UDP=4096,%,4096,4096,0,edns0[len=0,UDP=4096,%' | \
-  sed 's%,41,41,0,edns0\[len=0,UDP=512,%,512,512,0,edns0[len=0,UDP=512,%' >test8.new
-mv test8.new test8.out
-cat test8.layer.out | \
-  sed 's%,CLASS4096,OPT,%,4096,4096,%' | \
-  sed 's%,CLASS512,OPT,%,512,512,%' | \
-  sed 's%,41,41,0,edns0\[len=0,UDP=4096,%,4096,4096,0,edns0[len=0,UDP=4096,%' | \
-  sed 's%,41,41,0,edns0\[len=0,UDP=512,%,512,512,0,edns0[len=0,UDP=512,%' >test8.layer.new
-mv test8.layer.new test8.layer.out
-
 diff test8.out "$srcdir/test8.gold"
 diff test8.layer.out "$srcdir/test8.gold"

--- a/src/test/test9.sh
+++ b/src/test/test9.sh
@@ -3,19 +3,4 @@
 ../dnscap -r dns.pcap-dist -g -B '2016-10-20 15:23:30' -E '2016-10-20 15:24:00' 2>test9.out
 ../dnscap -r dns.pcap-dist -o use_layers=yes -g -B '2016-10-20 15:23:30' -E '2016-10-20 15:24:00' 2>>test9.out
 
-osrel=`uname -s`
-if [ "$osrel" = "OpenBSD" ]; then
-    mv test9.out test9.out.old
-    grep -v "^dnscap.*WARNING.*symbol.*relink" test9.out.old > test9.out
-    rm test9.out.old
-fi
-
-# TODO: Remove when #133 is fixed
-cat test9.out | \
-  sed 's%,CLASS4096,OPT,%,4096,4096,%' | \
-  sed 's%,CLASS512,OPT,%,512,512,%' | \
-  sed 's%,41,41,0,edns0\[len=0,UDP=4096,%,4096,4096,0,edns0[len=0,UDP=4096,%' | \
-  sed 's%,41,41,0,edns0\[len=0,UDP=512,%,512,512,0,edns0[len=0,UDP=512,%' >test9.new
-mv test9.new test9.out
-
 diff test9.out "$srcdir/test9.gold"


### PR DESCRIPTION
- Fix #167: Add `-q` and `-Q` to filter on matched/not matched QTYPE
- Add a bit better usage output, related option
- Clean up tests, remove OpenBSD and EDNS work-arounds