### PR TITLE
v6bug, interval

### DIFF
--- a/plugins/anonaes128/test2.sh
+++ b/plugins/anonaes128/test2.sh
@@ -8,9 +8,9 @@ fi
 
 ln -fs "$srcdir/../../src/test/dns6.pcap" dns6.pcap-dist
 
-../../src/dnscap -r dns6.pcap-dist -6 -g -P "$plugin" -k "some 16-byte key" -i "some 16-byte key" 2>test2.out
-../../src/dnscap -r dns6.pcap-dist -6 -g -P "$plugin" -k "some 16-byte key" -i "some 16-byte key" -c 2>>test2.out
-../../src/dnscap -r dns6.pcap-dist -6 -g -P "$plugin" -k "some 16-byte key" -i "some 16-byte key" -s 2>>test2.out
+../../src/dnscap -r dns6.pcap-dist -g -P "$plugin" -k "some 16-byte key" -i "some 16-byte key" 2>test2.out
+../../src/dnscap -r dns6.pcap-dist -g -P "$plugin" -k "some 16-byte key" -i "some 16-byte key" -c 2>>test2.out
+../../src/dnscap -r dns6.pcap-dist -g -P "$plugin" -k "some 16-byte key" -i "some 16-byte key" -s 2>>test2.out
 
 osrel=`uname -s`
 if [ "$osrel" = "OpenBSD" ]; then

--- a/plugins/anonaes128/test3.sh
+++ b/plugins/anonaes128/test3.sh
@@ -8,8 +8,8 @@ fi
 
 ln -fs "$srcdir/../../src/test/dns6.pcap" dns6.pcap-dist
 
-../../src/dnscap -r dns6.pcap-dist -w test3.pcap -6 -P "$plugin" -k "some 16-byte key" -i "some 16-byte key" 2>test3.out
-../../src/dnscap -r test3.pcap.20181127.155200.414188 -6 -g -P "$plugin" -D -k "some 16-byte key" -i "some 16-byte key" 2>>test3.out
+../../src/dnscap -r dns6.pcap-dist -w test3.pcap -P "$plugin" -k "some 16-byte key" -i "some 16-byte key" 2>test3.out
+../../src/dnscap -r test3.pcap.20181127.155200.414188 -g -P "$plugin" -D -k "some 16-byte key" -i "some 16-byte key" 2>>test3.out
 
 osrel=`uname -s`
 if [ "$osrel" = "OpenBSD" ]; then

--- a/plugins/anonmask/test2.sh
+++ b/plugins/anonmask/test2.sh
@@ -8,13 +8,13 @@ fi
 
 ln -fs "$srcdir/../../src/test/dns6.pcap" dns6.pcap-dist
 
-../../src/dnscap -r dns6.pcap-dist -6 -g -P "$plugin" 2>test2.out
-../../src/dnscap -r dns6.pcap-dist -6 -g -P "$plugin" -6 24 2>>test2.out
-../../src/dnscap -r dns6.pcap-dist -6 -g -P "$plugin" -6 32 2>>test2.out
-../../src/dnscap -r dns6.pcap-dist -6 -g -P "$plugin" -6 64 2>>test2.out
-../../src/dnscap -r dns6.pcap-dist -6 -g -P "$plugin" -6 96 2>>test2.out
-../../src/dnscap -r dns6.pcap-dist -6 -g -P "$plugin" -c 2>>test2.out
-../../src/dnscap -r dns6.pcap-dist -6 -g -P "$plugin" -s 2>>test2.out
+../../src/dnscap -r dns6.pcap-dist -g -P "$plugin" 2>test2.out
+../../src/dnscap -r dns6.pcap-dist -g -P "$plugin" -6 24 2>>test2.out
+../../src/dnscap -r dns6.pcap-dist -g -P "$plugin" -6 32 2>>test2.out
+../../src/dnscap -r dns6.pcap-dist -g -P "$plugin" -6 64 2>>test2.out
+../../src/dnscap -r dns6.pcap-dist -g -P "$plugin" -6 96 2>>test2.out
+../../src/dnscap -r dns6.pcap-dist -g -P "$plugin" -c 2>>test2.out
+../../src/dnscap -r dns6.pcap-dist -g -P "$plugin" -s 2>>test2.out
 
 osrel=`uname -s`
 if [ "$osrel" = "OpenBSD" ]; then

--- a/plugins/cryptopan/test2.sh
+++ b/plugins/cryptopan/test2.sh
@@ -8,9 +8,9 @@ fi
 
 ln -fs "$srcdir/../../src/test/dns6.pcap" dns6.pcap-dist
 
-../../src/dnscap -r dns6.pcap-dist -6 -g -P "$plugin" -6 -k "some 16-byte key" -i "some 16-byte key" -a "some 16-byte key" 2>test2.out
-../../src/dnscap -r dns6.pcap-dist -6 -g -P "$plugin" -6 -k "some 16-byte key" -i "some 16-byte key" -a "some 16-byte key" -c 2>>test2.out
-../../src/dnscap -r dns6.pcap-dist -6 -g -P "$plugin" -6 -k "some 16-byte key" -i "some 16-byte key" -a "some 16-byte key" -s 2>>test2.out
+../../src/dnscap -r dns6.pcap-dist -g -P "$plugin" -6 -k "some 16-byte key" -i "some 16-byte key" -a "some 16-byte key" 2>test2.out
+../../src/dnscap -r dns6.pcap-dist -g -P "$plugin" -6 -k "some 16-byte key" -i "some 16-byte key" -a "some 16-byte key" -c 2>>test2.out
+../../src/dnscap -r dns6.pcap-dist -g -P "$plugin" -6 -k "some 16-byte key" -i "some 16-byte key" -a "some 16-byte key" -s 2>>test2.out
 
 osrel=`uname -s`
 if [ "$osrel" = "OpenBSD" ]; then

--- a/plugins/cryptopan/test3.sh
+++ b/plugins/cryptopan/test3.sh
@@ -10,9 +10,9 @@ ln -fs "$srcdir/../../src/test/dns.pcap" dns.pcap-dist
 ln -fs "$srcdir/../../src/test/dns6.pcap" dns6.pcap-dist
 
 ../../src/dnscap -w test3.pcap -r dns.pcap-dist -P "$plugin" -k "some 16-byte key" -i "some 16-byte key" -a "some 16-byte key" 2>test3.out
-../../src/dnscap -w test3.pcap -r dns6.pcap-dist -6 -P "$plugin" -k "some 16-byte key" -i "some 16-byte key" -a "some 16-byte key" -6 2>>test3.out
+../../src/dnscap -w test3.pcap -r dns6.pcap-dist -P "$plugin" -k "some 16-byte key" -i "some 16-byte key" -a "some 16-byte key" -6 2>>test3.out
 ../../src/dnscap -r test3.pcap.20161020.152301.075993 -g -P "$plugin" -k "some 16-byte key" -i "some 16-byte key" -a "some 16-byte key" -D 2>>test3.out
-../../src/dnscap -r test3.pcap.20181127.155200.414188 -6 -g -P "$plugin" -k "some 16-byte key" -i "some 16-byte key" -a "some 16-byte key" -6 -D 2>>test3.out
+../../src/dnscap -r test3.pcap.20181127.155200.414188 -g -P "$plugin" -k "some 16-byte key" -i "some 16-byte key" -a "some 16-byte key" -6 -D 2>>test3.out
 
 osrel=`uname -s`
 if [ "$osrel" = "OpenBSD" ]; then

--- a/plugins/cryptopant/test2.sh
+++ b/plugins/cryptopant/test2.sh
@@ -8,16 +8,16 @@ fi
 
 ln -fs "$srcdir/../../src/test/dns6.pcap" dns6.pcap-dist
 
-../../src/dnscap -r dns6.pcap-dist -6 -g -P "$plugin" 2>test2.out || true
+../../src/dnscap -r dns6.pcap-dist -g -P "$plugin" 2>test2.out || true
 if grep -q "no cryptopANT support built in" test2.out 2>/dev/null; then
     echo "No cryptopANT support, skipping tests"
     exit 0
 fi
 
-../../src/dnscap -r dns6.pcap-dist -6 -g -P "$plugin" -k "$srcdir/keyfile" 2>test2.out
-../../src/dnscap -r dns6.pcap-dist -6 -g -P "$plugin" -k "$srcdir/keyfile" -6 24 2>test2.out
-../../src/dnscap -r dns6.pcap-dist -6 -g -P "$plugin" -k "$srcdir/keyfile" -c 2>>test2.out
-../../src/dnscap -r dns6.pcap-dist -6 -g -P "$plugin" -k "$srcdir/keyfile" -s 2>>test2.out
+../../src/dnscap -r dns6.pcap-dist -g -P "$plugin" -k "$srcdir/keyfile" 2>test2.out
+../../src/dnscap -r dns6.pcap-dist -g -P "$plugin" -k "$srcdir/keyfile" -6 24 2>test2.out
+../../src/dnscap -r dns6.pcap-dist -g -P "$plugin" -k "$srcdir/keyfile" -c 2>>test2.out
+../../src/dnscap -r dns6.pcap-dist -g -P "$plugin" -k "$srcdir/keyfile" -s 2>>test2.out
 
 osrel=`uname -s`
 if [ "$osrel" = "OpenBSD" ]; then

--- a/plugins/cryptopant/test3.sh
+++ b/plugins/cryptopant/test3.sh
@@ -16,9 +16,9 @@ if grep -q "no cryptopANT support built in" test3.out 2>/dev/null; then
 fi
 
 ../../src/dnscap -w test3.pcap -r dns.pcap-dist -P "$plugin" -k "$srcdir/keyfile" 2>test3.out
-../../src/dnscap -w test3.pcap -r dns6.pcap-dist -6 -P "$plugin" -k "$srcdir/keyfile" 2>>test3.out
+../../src/dnscap -w test3.pcap -r dns6.pcap-dist -P "$plugin" -k "$srcdir/keyfile" 2>>test3.out
 ../../src/dnscap -r test3.pcap.20161020.152301.075993 -g -P "$plugin" -k "$srcdir/keyfile" -D 2>>test3.out
-../../src/dnscap -r test3.pcap.20181127.155200.414188 -6 -g -P "$plugin" -k "$srcdir/keyfile" -D 2>>test3.out
+../../src/dnscap -r test3.pcap.20181127.155200.414188 -g -P "$plugin" -k "$srcdir/keyfile" -D 2>>test3.out
 
 osrel=`uname -s`
 if [ "$osrel" = "OpenBSD" ]; then

--- a/plugins/eventlog/test1.sh
+++ b/plugins/eventlog/test1.sh
@@ -18,5 +18,5 @@ ln -fs "$srcdir/../../src/test/dnso1tcp.pcap" dnso1tcp.pcap-dist
 ../../src/dnscap -r dns.pcap-dist -g -P "$plugin" -n test
 ! ../../src/dnscap -r dns.pcap-dist -g -P "$plugin" -X
 
-../../src/dnscap -6 -r dns6.pcap-dist -g -P "$plugin"
+../../src/dnscap -r dns6.pcap-dist -g -P "$plugin"
 ../../src/dnscap -T -r dnso1tcp.pcap-dist -g -P "$plugin"

--- a/plugins/ipcrypt/test2.sh
+++ b/plugins/ipcrypt/test2.sh
@@ -8,9 +8,9 @@ fi
 
 ln -fs "$srcdir/../../src/test/dns6.pcap" dns6.pcap-dist
 
-../../src/dnscap -r dns6.pcap-dist -6 -g -P "$plugin" -6 -k "some 16-byte key" 2>test2.out
-../../src/dnscap -r dns6.pcap-dist -6 -g -P "$plugin" -6 -k "some 16-byte key" -c 2>>test2.out
-../../src/dnscap -r dns6.pcap-dist -6 -g -P "$plugin" -6 -k "some 16-byte key" -s 2>>test2.out
+../../src/dnscap -r dns6.pcap-dist -g -P "$plugin" -6 -k "some 16-byte key" 2>test2.out
+../../src/dnscap -r dns6.pcap-dist -g -P "$plugin" -6 -k "some 16-byte key" -c 2>>test2.out
+../../src/dnscap -r dns6.pcap-dist -g -P "$plugin" -6 -k "some 16-byte key" -s 2>>test2.out
 
 osrel=`uname -s`
 if [ "$osrel" = "OpenBSD" ]; then

--- a/plugins/ipcrypt/test3.sh
+++ b/plugins/ipcrypt/test3.sh
@@ -10,9 +10,9 @@ ln -fs "$srcdir/../../src/test/dns.pcap" dns.pcap-dist
 ln -fs "$srcdir/../../src/test/dns6.pcap" dns6.pcap-dist
 
 ../../src/dnscap -w test3.pcap -r dns.pcap-dist -P "$plugin" -k "some 16-byte key" 2>test3.out
-../../src/dnscap -w test3.pcap -r dns6.pcap-dist -6 -P "$plugin" -k "some 16-byte key" -6 2>>test3.out
+../../src/dnscap -w test3.pcap -r dns6.pcap-dist -P "$plugin" -k "some 16-byte key" -6 2>>test3.out
 ../../src/dnscap -r test3.pcap.20161020.152301.075993 -g -P "$plugin" -k "some 16-byte key" -D 2>>test3.out
-../../src/dnscap -r test3.pcap.20181127.155200.414188 -6 -g -P "$plugin" -k "some 16-byte key" -6 -D 2>>test3.out
+../../src/dnscap -r test3.pcap.20181127.155200.414188 -g -P "$plugin" -k "some 16-byte key" -6 -D 2>>test3.out
 
 osrel=`uname -s`
 if [ "$osrel" = "OpenBSD" ]; then

--- a/plugins/rssm/test3.sh
+++ b/plugins/rssm/test3.sh
@@ -6,6 +6,6 @@ if [ -z "$plugin" ]; then
     exit 1
 fi
 
-../../src/dnscap -N -T -6 -r "$srcdir/../../src/test/dns6.pcap" -P "$plugin" -w test3 -Y -n test3 -A -S -D
+../../src/dnscap -N -T -r "$srcdir/../../src/test/dns6.pcap" -P "$plugin" -w test3 -Y -n test3 -A -S -D
 
 diff test3.20181127.155200.414188 "$srcdir/test3.gold"

--- a/src/args.c
+++ b/src/args.c
@@ -152,7 +152,7 @@ void help_1(void)
     fprintf(stderr, "%s: version %s\n\n", ProgramName, PACKAGE_VERSION);
     fprintf(stderr,
         "usage: %s\n"
-        "  [-?VbNpd1g6fTI"
+        "  [-?VbNpd1gfTI"
 #ifdef USE_SECCOMP
         "y"
 #endif
@@ -185,7 +185,6 @@ void help_2(void)
         "             times to increase debugging\n"
         "  -1         flush output on every packet\n"
         "  -g         dump packets dig-style on stderr\n"
-        "  -6         (deprecated) compensate for PCAP/BPF IPv6 bug\n"
         "  -f         include fragmented packets\n"
         "  -T         include TCP packets (DNS header filters will inspect only the\n"
         "             first DNS header, and the result will apply to all messages\n"
@@ -285,7 +284,7 @@ void parse_args(int argc, char* argv[])
     INIT_LIST(plugins);
     while ((ch = getopt(argc, argv,
                 "a:bc:de:fgh:i:k:l:m:o:pr:s:t:u:w:x:yz:q:"
-                "A:B:C:DE:F:IL:MNP:STU:VW:X:Y:Z:Q:16?"))
+                "A:B:C:DE:F:IL:MNP:STU:VW:X:Y:Z:Q:1?"))
            != EOF) {
         switch (ch) {
         case 'o':
@@ -311,9 +310,6 @@ void parse_args(int argc, char* argv[])
             break;
         case 'g':
             preso = TRUE;
-            break;
-        case '6':
-            v6bug = TRUE;
             break;
         case 'f':
             wantfrags = TRUE;

--- a/src/bpft.c
+++ b/src/bpft.c
@@ -99,7 +99,7 @@ void prepare_bpft(void)
          * not mbs/mbc. */
     }
     len += text_add(&bpfl, " ( udp port %d and ( ip6 or ( ip", dns_port);
-    // if (!v6bug) {
+
     if (udp10_mbc != 0)
         len += text_add(&bpfl, " and udp[10] & 0x%x = 0",
             udp10_mbc);
@@ -122,7 +122,7 @@ void prepare_bpft(void)
         }
         len += text_add(&bpfl, " 0x%x << (udp[11] & 0xf) & 0x%x != 0 )", ERR_RCODE_BASE, err_wanted);
     }
-    // }
+
     len += text_add(&bpfl, " )))"); /*  ... udp 53 ) */
     len += text_add(&bpfl, " )"); /*  ... ports ) */
     if (options.bpf_hosts_apply_all) {

--- a/src/dnscap.c
+++ b/src/dnscap.c
@@ -96,7 +96,6 @@ int             monitor_mode   = FALSE;
 int             immediate_mode = FALSE;
 int             background     = FALSE;
 char            errbuf[PCAP_ERRBUF_SIZE];
-int             v6bug     = FALSE;
 int             wantgzip  = 0;
 int             wantfrags = FALSE;
 int             wanticmp  = FALSE;

--- a/src/dnscap.h
+++ b/src/dnscap.h
@@ -413,7 +413,6 @@ extern int             monitor_mode;
 extern int             immediate_mode;
 extern int             background;
 extern char            errbuf[PCAP_ERRBUF_SIZE];
-extern int             v6bug;
 extern int             wantgzip;
 extern int             wantfrags;
 extern int             wanticmp;

--- a/src/network.c
+++ b/src/network.c
@@ -216,8 +216,14 @@ void layer_pkt(u_char* user, const pcap_thread_packet_t* packet, const u_char* p
         }
     }
 
-    if (next_interval != 0 && firstpkt->pkthdr.ts.tv_sec >= next_interval && dumper_opened == dump_state)
-        dumper_close(firstpkt->pkthdr.ts);
+    if (next_interval != 0 && firstpkt->pkthdr.ts.tv_sec >= next_interval) {
+        if (preso)
+            goto breakloop;
+        if (dumper_opened == dump_state)
+            dumper_close(firstpkt->pkthdr.ts);
+        if (dump_type == to_stdout)
+            goto breakloop;
+    }
     if (dumper_closed == dump_state && dumper_open(firstpkt->pkthdr.ts))
         goto breakloop;
 
@@ -417,8 +423,14 @@ void dl_pkt(u_char* user, const struct pcap_pkthdr* hdr, const u_char* pkt, cons
         descr[0] = '\0';
     }
 
-    if (next_interval != 0 && hdr->ts.tv_sec >= next_interval && dumper_opened == dump_state)
-        dumper_close(hdr->ts);
+    if (next_interval != 0 && hdr->ts.tv_sec >= next_interval) {
+        if (preso)
+            goto breakloop;
+        if (dumper_opened == dump_state)
+            dumper_close(hdr->ts);
+        if (dump_type == to_stdout)
+            goto breakloop;
+    }
     if (dumper_closed == dump_state && dumper_open(hdr->ts))
         goto breakloop;
 

--- a/src/test/test10.sh
+++ b/src/test/test10.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -xe
 
-../dnscap -r dns6.pcap-dist -6 -g 2>test10.out
-../dnscap -r dns6.pcap-dist -6 -o use_layers=yes -g 2>>test10.out
+../dnscap -r dns6.pcap-dist -g 2>test10.out
+../dnscap -r dns6.pcap-dist -o use_layers=yes -g 2>>test10.out
 
 diff test10.out "$srcdir/test10.gold"


### PR DESCRIPTION
- Remove deprecated `-6` option
- Issue #244: Fix interaction with `-t` and `-g`/packet dump on stdout