### PR TITLE
eventlog.so imp(remove trailing newline for better readability (because duplicate) + answer on same line)

### DIFF
--- a/plugins/eventlog/eventlog.c
+++ b/plugins/eventlog/eventlog.c
@@ -374,7 +374,7 @@ void eventlog_output(const char* descr, iaddr from, iaddr to, uint8_t proto, uns
 
         ldns_buffer_clear(buf);
         if (ldns_rdf2buffer_str(buf, ldns_rr_owner(qd)) == LDNS_STATUS_OK) {
-            fprintf(out, " name=%s\n", (char*)ldns_buffer_begin(buf));
+            fprintf(out, " name=%s", (char*)ldns_buffer_begin(buf));
         } else {
             fprintf(out, " **ERROR parsing response record**\n");
             ldns_pkt_free(pkt);


### PR DESCRIPTION
I needed a clean output to forward to my SIEM for easier parsing. This means one line must contain all the data for it to be parsed together.
So far :
- the newline forced the answer to be on a new, separate line in the output file
- blank lines were found between each event
This PR fixes both, and allows me to forward these events directly to my SIEM.