### PR TITLE
PID file

### DIFF
--- a/src/dnscap.1.in
+++ b/src/dnscap.1.in
@@ -163,6 +163,9 @@ functions, unless options
 .B \-N
 is given or only reading from files.
 .TP
+.BI "\-o pid_file" =...
+Specify the file to write the PID to when running as a daemon (default none).
+.TP
 .BI "\-o user" =...
 Specify the user to drop privileges to (default nobody).
 .TP

--- a/src/options.c
+++ b/src/options.c
@@ -228,6 +228,13 @@ int option_parse(options_t* options, const char* option)
             options->bpf_hosts_apply_all = 1;
             return 0;
         }
+    } else if (have("pid_file")) {
+        if (options->pid_file) {
+            free(options->pid_file);
+        }
+        if ((options->pid_file = strdup(argument))) {
+            return 0;
+        }
     }
 
     return 1;
@@ -243,6 +250,10 @@ void options_free(options_t* options)
         if (options->group) {
             free(options->group);
             options->group = 0;
+        }
+        if (options->pid_file) {
+            free(options->pid_file);
+            options->pid_file = 0;
         }
     }
 }

--- a/src/options.h
+++ b/src/options.h
@@ -72,6 +72,8 @@ enum dump_format {
 \
     0, 0, 0, 0, 0, \
 \
+    0, \
+\
     0 \
 }
 
@@ -113,6 +115,8 @@ struct options {
     int    reassemble_tcp_bfbparsedns;
 
     int bpf_hosts_apply_all;
+
+    char* pid_file;
 };
 
 int  option_parse(options_t* options, const char* option);


### PR DESCRIPTION
- Fix #267: Add option `-o pid_file=<file>` for writing a PID file when running as daemon