### PR TITLE
Better test for presence of EDNS option with extended error code

### DIFF
--- a/plugins/rssm/rssm.c
+++ b/plugins/rssm/rssm.c
@@ -721,7 +721,7 @@ void rssm_output(const char* descr, iaddr from, iaddr to, uint8_t proto, unsigne
                 counts.dns_tcp_responses_sent_ipv6++;
             }
         }
-        if (ldns_pkt_arcount(pkt)) {
+        if (ldns_pkt_edns(pkt)) {
             rcode |= ((uint16_t)ldns_pkt_edns_extended_rcode(pkt) << 4);
         }
         counts.rcodes[rcode]++;


### PR DESCRIPTION
ldns libraries "consume" the OPT Additional Records such that the arcount is decremented for each OPT.  If a packet has only OPT records in AR section, then this test for ldns_pkt_arcount() returns zero, and does not add any extended error code bits.