### PR TITLE
Adding hash table in front of tcpstate lists for performance.  Adjusting how often we call tcpstate garbage collection.

### DIFF
--- a/src/dnscap.c
+++ b/src/dnscap.c
@@ -55,6 +55,10 @@
 #define INIT_OPENSSL 1
 #endif
 
+extern int tcpstate_cmp (const void* _a, const void* _b);
+extern unsigned int tcpstate_hash (const void *key);
+hashtbl *tcpstate_hashtbl = NULL;
+
 plugin_list     plugins;
 const char*     ProgramName = "amnesia";
 int             dumptrace   = 0;
@@ -65,7 +69,6 @@ unsigned        msg_wanted = MSG_QUERY;
 unsigned        dir_wanted = DIR_INITIATE | DIR_RESPONSE;
 unsigned        end_hide   = 0U;
 unsigned        err_wanted = ERR_NO | ERR_YES; /* accept all by default */
-tcpstate_list   tcpstates;
 int             tcpstate_count = 0;
 endpoint_list   initiators, not_initiators;
 endpoint_list   responders, not_responders;
@@ -156,7 +159,11 @@ int main(int argc, char* argv[])
             exit(1);
         }
     }
-    INIT_LIST(tcpstates);
+    tcpstate_hashtbl = hash_create (TCPSTATE_HASH_TABLE_SIZE, tcpstate_hash, tcpstate_cmp, NULL);
+    if (tcpstate_hashtbl == NULL) {
+        logerr("Error allocating TCP hash table");
+        exit(1);
+    }
 
     if (!dont_drop_privileges && !only_offline_pcaps) {
         drop_privileges();
@@ -237,6 +244,7 @@ int main(int argc, char* argv[])
         if (p->stop)
             (*p->stop)();
     }
+    hash_free (tcpstate_hashtbl);
     options_free(&options);
 
 #ifdef INIT_OPENSSL

--- a/src/dnscap.h
+++ b/src/dnscap.h
@@ -214,6 +214,7 @@
 #include "dump_cbor.h"
 #include "dump_cds.h"
 #include "options.h"
+#include "hashtbl.h"
 #include "pcap-thread/pcap_thread.h"
 
 struct text {
@@ -249,6 +250,7 @@ typedef LIST(struct vlan) vlan_list;
 #define MAX_TCP_SEGS 8
 #define MAX_TCP_HOLES 8
 #define MAX_TCP_DNS_MSG 8
+#define TCPSTATE_HASH_TABLE_SIZE 4096
 
 typedef struct tcphole    tcphole_t;
 typedef struct tcp_msgbuf tcp_msgbuf_t;
@@ -317,6 +319,7 @@ struct tcpstate {
 };
 typedef struct tcpstate* tcpstate_ptr;
 typedef LIST(struct tcpstate) tcpstate_list;
+extern hashtbl *tcpstate_hashtbl;
 
 struct endpoint {
     LINK(struct endpoint)
@@ -382,7 +385,6 @@ extern unsigned        msg_wanted;
 extern unsigned        dir_wanted;
 extern unsigned        end_hide;
 extern unsigned        err_wanted;
-extern tcpstate_list   tcpstates;
 extern int             tcpstate_count;
 extern endpoint_list   initiators, not_initiators;
 extern endpoint_list   responders, not_responders;

--- a/src/network.c
+++ b/src/network.c
@@ -720,14 +720,7 @@ void network_pkt2(const char* descr, my_bpftimeval ts, const pcap_thread_packet_
             _curr_tcpstate = 0;
 
             /* End of stream; deallocate the tcpstate. */
-            if (tcpstate) {
-                UNLINK(tcpstates, tcpstate, link);
-                if (tcpstate->reasm) {
-                    tcpreasm_free(tcpstate->reasm);
-                }
-                free(tcpstate);
-                tcpstate_count--;
-            }
+            tcpstate_discard(tcpstate, "FIN/RST");
             return;
         }
         if (packet->tcphdr.th_flags & TH_SYN) {
@@ -1304,14 +1297,7 @@ void network_pkt(const char* descr, my_bpftimeval ts, unsigned pf,
                 pkt_copy, olen, NULL, 0);
             _curr_tcpstate = 0;
             /* End of stream; deallocate the tcpstate. */
-            if (tcpstate) {
-                UNLINK(tcpstates, tcpstate, link);
-                if (tcpstate->reasm) {
-                    tcpreasm_free(tcpstate->reasm);
-                }
-                free(tcpstate);
-                tcpstate_count--;
-            }
+            tcpstate_discard(tcpstate, "FIN/RST");
             goto network_pkt_end;
         }
         if (tcp->th_flags & TH_SYN) {


### PR DESCRIPTION

This approach uses the existing hashtbl code versus implementing from-scratch.
Like the from-scratch code, I use the hash table only to hold a single value
which is a list of tcpstates.  This is important because the individual lists
need to be flexible to bring most-recently-used tcpstates to the front of the
list and to be able to walk the lists easily for garbage collection.

Garbage collection (GC) of tcpstates now takes place over all LISTS in the hash
table.  Since this is much more expensive now, I only attempt GC every N=100 calls
to tcpstate_find() [about every N=100 TCP packets].  GC is still subject to a timer
and a tcpstate_counter threshhold (which has also been increased significantly).

Another, potential issue that I tried to address is when a new tcpstate cannot be
allocated due to a alloc failure.  The original code just stole a tcpstate from
the back of the [single] list and re-used it.  That doesn't change, except I
now free the tcpstate->reasm structure (if allocated) and zero-out all the other
struct tcpstate fields before reusing.  This should avoid dragging state from the
old tcp session in to the new one.  I have NOT been able to test this.