### PR TITLE
tcpstate on out of memory

### DIFF
--- a/plugins/anonaes128/anonaes128.c
+++ b/plugins/anonaes128/anonaes128.c
@@ -198,7 +198,14 @@ void anonaes128_getopt(int* argc, char** argv[])
     }
     if (!EVP_CipherInit_ex(ctx, EVP_aes_128_ecb(), NULL, key, iv, decrypt ? 0 : 1)) {
         unsigned long e = ERR_get_error();
-        fprintf(stderr, "%s:%s:%s", ERR_lib_error_string(e), ERR_func_error_string(e), ERR_reason_error_string(e));
+        fprintf(stderr, "%s:%s:%s\n",
+            ERR_lib_error_string(e),
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
+            ERR_func_error_string(e),
+#else
+            "",
+#endif
+            ERR_reason_error_string(e));
         usage("unable to initialize AES128 cipher");
     }
     EVP_CIPHER_CTX_set_padding(ctx, 0);

--- a/plugins/cryptopan/cryptopan.c
+++ b/plugins/cryptopan/cryptopan.c
@@ -228,7 +228,14 @@ void cryptopan_getopt(int* argc, char** argv[])
     }
     if (!EVP_CipherInit_ex(ctx, EVP_aes_128_ecb(), NULL, key, iv, 1)) {
         unsigned long e = ERR_get_error();
-        fprintf(stderr, "%s:%s:%s\n", ERR_lib_error_string(e), ERR_func_error_string(e), ERR_reason_error_string(e));
+        fprintf(stderr, "%s:%s:%s\n",
+            ERR_lib_error_string(e),
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
+            ERR_func_error_string(e),
+#else
+            "",
+#endif
+            ERR_reason_error_string(e));
         usage("unable to initialize AES128 cipher");
     }
     EVP_CIPHER_CTX_set_padding(ctx, 0);

--- a/src/tcpstate.c
+++ b/src/tcpstate.c
@@ -77,6 +77,8 @@ tcpstate_ptr tcpstate_find(iaddr from, iaddr to, unsigned sport, unsigned dport,
     return tcpstate;
 }
 
+tcpstate_ptr _curr_tcpstate = 0;
+
 tcpstate_ptr tcpstate_new(iaddr from, iaddr to, unsigned sport, unsigned dport)
 {
     tcpstate_ptr tcpstate = calloc(1, sizeof *tcpstate);
@@ -87,6 +89,13 @@ tcpstate_ptr tcpstate_new(iaddr from, iaddr to, unsigned sport, unsigned dport)
         tcpstate = TAIL(tcpstates);
         assert(tcpstate != NULL);
         UNLINK(tcpstates, tcpstate, link);
+        if (tcpstate->reasm) {
+            tcpreasm_free(tcpstate->reasm);
+        }
+        if (_curr_tcpstate == tcpstate) {
+            _curr_tcpstate = 0;
+        }
+        memset(tcpstate, 0, sizeof(*tcpstate));
     } else {
         tcpstate_count++;
     }
@@ -98,8 +107,6 @@ tcpstate_ptr tcpstate_new(iaddr from, iaddr to, unsigned sport, unsigned dport)
     PREPEND(tcpstates, tcpstate, link);
     return tcpstate;
 }
-
-tcpstate_ptr _curr_tcpstate = 0;
 
 tcpstate_ptr tcpstate_getcurr(void)
 {


### PR DESCRIPTION
- `tcpstate`: Zero out `tcpstate` when reusing the oldest state during out-of-memory event, related to Issue #285