### PR TITLE
Adding hash table in front of tcpstate lists for performance and adjusting garbage collection frequency.

### DIFF
--- a/src/dnscap.h
+++ b/src/dnscap.h
@@ -214,6 +214,7 @@
 #include "dump_cbor.h"
 #include "dump_cds.h"
 #include "options.h"
+#include "hashtbl.h"
 #include "pcap-thread/pcap_thread.h"
 
 struct text {
@@ -249,6 +250,7 @@ typedef LIST(struct vlan) vlan_list;
 #define MAX_TCP_SEGS 8
 #define MAX_TCP_HOLES 8
 #define MAX_TCP_DNS_MSG 8
+#define TCPSTATE_HASH_TABLE_SIZE 4096
 
 typedef struct tcphole    tcphole_t;
 typedef struct tcp_msgbuf tcp_msgbuf_t;
@@ -317,6 +319,7 @@ struct tcpstate {
 };
 typedef struct tcpstate* tcpstate_ptr;
 typedef LIST(struct tcpstate) tcpstate_list;
+extern hashtbl *tcpstate_hashtbl;
 
 struct endpoint {
     LINK(struct endpoint)
@@ -382,7 +385,6 @@ extern unsigned        msg_wanted;
 extern unsigned        dir_wanted;
 extern unsigned        end_hide;
 extern unsigned        err_wanted;
-extern tcpstate_list   tcpstates;
 extern int             tcpstate_count;
 extern endpoint_list   initiators, not_initiators;
 extern endpoint_list   responders, not_responders;

--- a/src/network.c
+++ b/src/network.c
@@ -720,14 +720,7 @@ void network_pkt2(const char* descr, my_bpftimeval ts, const pcap_thread_packet_
             _curr_tcpstate = 0;
 
             /* End of stream; deallocate the tcpstate. */
-            if (tcpstate) {
-                UNLINK(tcpstates, tcpstate, link);
-                if (tcpstate->reasm) {
-                    tcpreasm_free(tcpstate->reasm);
-                }
-                free(tcpstate);
-                tcpstate_count--;
-            }
+            tcpstate_discard(tcpstate, "FIN/RST");
             return;
         }
         if (packet->tcphdr.th_flags & TH_SYN) {
@@ -1304,14 +1297,7 @@ void network_pkt(const char* descr, my_bpftimeval ts, unsigned pf,
                 pkt_copy, olen, NULL, 0);
             _curr_tcpstate = 0;
             /* End of stream; deallocate the tcpstate. */
-            if (tcpstate) {
-                UNLINK(tcpstates, tcpstate, link);
-                if (tcpstate->reasm) {
-                    tcpreasm_free(tcpstate->reasm);
-                }
-                free(tcpstate);
-                tcpstate_count--;
-            }
+            tcpstate_discard(tcpstate, "FIN/RST");
             goto network_pkt_end;
         }
         if (tcp->th_flags & TH_SYN) {

--- a/src/tcpstate.c
+++ b/src/tcpstate.c
@@ -40,55 +40,142 @@
 #include "tcpreasm.h"
 
 #define MAX_TCP_IDLE_TIME 600
-#define MAX_TCP_IDLE_COUNT 4096
+#define MAX_TCP_IDLE_COUNT (4096 * 512)
 #define TCP_GC_TIME 60
+#define GC_COUNTER_MAX 100
+
+void tcpstate_discard_from_list(tcpstate_list *list, tcpstate_ptr tcpstate, const char* msg);
+
+unsigned int
+tcpstate_hash (const void *key)
+{
+    const tcpstate_ptr tcpstate = (const tcpstate_ptr)key;
+    uint16_t *p;
+    unsigned int hash_val = 0;
+
+    if (tcpstate->saddr.af == AF_INET) {
+        p = (uint16_t *) &tcpstate->saddr.u.a4.s_addr;
+        hash_val += p[0]; hash_val += p[1];
+    } else if (tcpstate->saddr.af == AF_INET6) {
+        p = tcpstate->saddr.u.a6.s6_addr16;
+        hash_val += p[0]; hash_val += p[1]; hash_val += p[2]; hash_val += p[3];
+        hash_val += p[4]; hash_val += p[5]; hash_val += p[6]; hash_val += p[7];
+    }
+
+    if (tcpstate->daddr.af == AF_INET) {
+        p = (uint16_t *) &tcpstate->daddr.u.a4.s_addr;
+        hash_val += p[0]; hash_val += p[1];
+    } else if (tcpstate->daddr.af == AF_INET6) {
+        p = tcpstate->daddr.u.a6.s6_addr16;
+        hash_val += p[0]; hash_val += p[1]; hash_val += p[2]; hash_val += p[3];
+        hash_val += p[4]; hash_val += p[5]; hash_val += p[6]; hash_val += p[7];
+    }
+
+    hash_val += tcpstate->sport;
+    hash_val += tcpstate->dport;
+    return (hash_val);
+}
+
+int
+tcpstate_cmp (const void* _a, const void* _b)
+{
+    /* There will only be a single LIST() of tcpstates in each hash table
+     * slot.  Therefore, this cmp function will always match and return 0
+     */
+    return (0);
+}
+
+void tcpstate_gc (time_t t) {
+    static time_t next_gc = 0;
+    tcpstate_ptr  tcpstate;
+    int i;
+
+    if (tcpstate_hashtbl == NULL) return;
+    if ((t < next_gc) && (tcpstate_count < MAX_TCP_IDLE_COUNT)) return;
+
+    for (i=0; i < tcpstate_hashtbl->modulus; i++) {
+        hashitem *hi = tcpstate_hashtbl->items[i];
+        if ((hi != NULL) && (hi->data != NULL)) {
+            tcpstate_list *tcpstates_p = (tcpstate_list *)hi->data;
+            while ((tcpstate = TAIL(*tcpstates_p)) && (tcpstate->last_use < (t - MAX_TCP_IDLE_TIME))) {
+                tcpstate_discard_from_list (tcpstates_p, tcpstate, "gc stale");
+            }
+        }
+    }
+    next_gc = t + TCP_GC_TIME;
+    return;
+}
 
 tcpstate_ptr tcpstate_find(iaddr from, iaddr to, unsigned sport, unsigned dport, time_t t)
 {
-    static time_t next_gc = 0;
-    tcpstate_ptr  tcpstate;
+    tcpstate_list *tcpstates_p = NULL;
+    tcpstate_ptr tcpstate = NULL;
+    struct tcpstate this_tcpstate;
+    static int gc_counter = 0;
 
-#ifndef __clang_analyzer__
-    /* disabled during scan-build due to false-positives */
-    if (t >= next_gc || tcpstate_count > MAX_TCP_IDLE_COUNT) {
-        /* garbage collect stale states */
-        while ((tcpstate = TAIL(tcpstates)) && tcpstate->last_use < t - MAX_TCP_IDLE_TIME) {
-            tcpstate_discard(tcpstate, "gc stale");
-        }
-        next_gc = t + TCP_GC_TIME;
+    if (tcpstate_hashtbl == NULL) return (NULL);
+
+    /* Garbage collect every (GC_COUNTER_MAX) TCP packets */
+    if (gc_counter >= GC_COUNTER_MAX) {
+        tcpstate_gc(t);
+        gc_counter = 0;
+    } else {
+        gc_counter++;
     }
-#endif
 
-    for (tcpstate = HEAD(tcpstates);
-         tcpstate != NULL;
-         tcpstate = NEXT(tcpstate, link)) {
-        if (ia_equal(tcpstate->saddr, from) && ia_equal(tcpstate->daddr, to) && tcpstate->sport == sport && tcpstate->dport == dport)
+    this_tcpstate.saddr = from;
+    this_tcpstate.daddr = to;
+    this_tcpstate.sport = sport;
+    this_tcpstate.dport = dport;
+
+    tcpstates_p = hash_find (&this_tcpstate, tcpstate_hashtbl);
+    if (tcpstates_p != NULL) {
+        for (tcpstate = HEAD(*tcpstates_p);
+             tcpstate != NULL;
+             tcpstate = NEXT(tcpstate, link)) {
+            if (ia_equal(tcpstate->saddr, from) && ia_equal(tcpstate->daddr, to) && tcpstate->sport == sport && tcpstate->dport == dport)
             break;
-    }
-    if (tcpstate != NULL) {
-        tcpstate->last_use = t;
-        if (tcpstate != HEAD(tcpstates)) {
-            /* move to beginning of list */
-            UNLINK(tcpstates, tcpstate, link);
-            PREPEND(tcpstates, tcpstate, link);
+        }
+        if (tcpstate != NULL) {
+            tcpstate->last_use = t;
+            if (tcpstate != HEAD(*tcpstates_p)) {
+                /* move to beginning of list */
+                UNLINK(*tcpstates_p, tcpstate, link);
+                PREPEND(*tcpstates_p, tcpstate, link);
+            }
         }
     }
-
-    return tcpstate;
+    return (tcpstate);
 }
 
 tcpstate_ptr _curr_tcpstate = 0;
 
 tcpstate_ptr tcpstate_new(iaddr from, iaddr to, unsigned sport, unsigned dport)
 {
+    tcpstate_list *tcpstates_p = NULL;
+    struct tcpstate tmp_tcpstate;
+
+    tmp_tcpstate.saddr = from;
+    tmp_tcpstate.daddr = to;
+    tmp_tcpstate.sport = sport;
+    tmp_tcpstate.dport = dport;
+
+    tcpstates_p = hash_find (&tmp_tcpstate, tcpstate_hashtbl);
+    if (tcpstates_p == NULL) {
+        tcpstates_p = calloc (1, sizeof (*tcpstates_p));
+        assert (tcpstates_p);
+        INIT_LIST (*tcpstates_p);
+        hash_add (&tmp_tcpstate, tcpstates_p, tcpstate_hashtbl);
+    }
+
     tcpstate_ptr tcpstate = calloc(1, sizeof *tcpstate);
     if (tcpstate == NULL) {
         /* Out of memory; recycle the least recently used */
         logerr("warning: out of memory, "
                "discarding some TCP state early");
-        tcpstate = TAIL(tcpstates);
+        tcpstate = TAIL(*tcpstates_p);
         assert(tcpstate != NULL);
-        UNLINK(tcpstates, tcpstate, link);
+        UNLINK(*tcpstates_p, tcpstate, link);
         if (tcpstate->reasm) {
             tcpreasm_free(tcpstate->reasm);
         }
@@ -104,7 +191,7 @@ tcpstate_ptr tcpstate_new(iaddr from, iaddr to, unsigned sport, unsigned dport)
     tcpstate->sport = sport;
     tcpstate->dport = dport;
     INIT_LINK(tcpstate, link);
-    PREPEND(tcpstates, tcpstate, link);
+    PREPEND(*tcpstates_p, tcpstate, link);
     return tcpstate;
 }
 
@@ -113,22 +200,31 @@ tcpstate_ptr tcpstate_getcurr(void)
     return _curr_tcpstate;
 }
 
+void tcpstate_discard_from_list(tcpstate_list *list, tcpstate_ptr tcpstate, const char* msg)
+{
+    if ((list == NULL) || (tcpstate == NULL)) return;
+    UNLINK(*list, tcpstate, link);
+    if (tcpstate->reasm) {
+        tcpreasm_free(tcpstate->reasm);
+    }
+    free(tcpstate);
+    if (_curr_tcpstate == tcpstate) {
+        _curr_tcpstate = 0;
+    }
+    tcpstate_count--;
+    return;
+}
+
 /* Discard this packet.  If it's part of TCP stream, all subsequent pkts on
  * the same tcp stream will also be discarded. */
 void tcpstate_discard(tcpstate_ptr tcpstate, const char* msg)
 {
+    tcpstate_list *tcpstates_p;
     if (dumptrace >= 3 && msg)
         fprintf(stderr, "discarding packet: %s\n", msg);
     if (tcpstate) {
-        UNLINK(tcpstates, tcpstate, link);
-        if (tcpstate->reasm) {
-            tcpreasm_free(tcpstate->reasm);
-        }
-        free(tcpstate);
-        if (_curr_tcpstate == tcpstate) {
-            _curr_tcpstate = 0;
-        }
-        tcpstate_count--;
+        tcpstates_p = hash_find (tcpstate, tcpstate_hashtbl);
+        tcpstate_discard_from_list(tcpstates_p, tcpstate, msg);
     }
 }
 


### PR DESCRIPTION
Adding a has table in front of tcpstates to improve performance.  The hash table consists only of a LIST() of tcpstates.  This preserves the functionality of moving most-recently-used  tcpstates to the front of a list, while distributing states among many LIST() objects.  Adjusting the garbage collection frequency to avoid calling it on every new state when we have many concurrent sessions.