### PR TITLE
Diag output

### DIFF
--- a/src/dnscap.1.in
+++ b/src/dnscap.1.in
@@ -798,6 +798,10 @@ First line contains packet and capturing information:
   [<pktsize>] <date> <timestamp> [<pktnum> <file|interface> <vlanid>]
 .EE
 
+Note;
+.B pktsize
+is before parsing the IPv4/v6 packet and can include padding.
+
 Second line shows IP information or if the packet is a fragment:
 
 .EX
@@ -845,6 +849,14 @@ Each DNS record contains the following:
 
 .EX
   <fqdn>,<class>,<type>[,<ttl>[,<additional information>]]
+.EE
+
+Note; comma characters in
+.B fqdn
+will be quoted with a backslash, for example:
+
+.EX
+  1 exam\\,ple.com.,IN,A 0 0 0
 .EE
 
 Additional information will be displayed for SOA, A, AAAA, MX, NS, PTR,

--- a/src/dump_dns.c
+++ b/src/dump_dns.c
@@ -66,7 +66,13 @@ static void dump_dns_rr(ldns_rr* rr, FILE* trace, ldns_buffer* lbuf, bool qsect)
     if (ldns_rdf2buffer_str(lbuf, ldns_rr_owner(rr)) != LDNS_STATUS_OK) {
         goto error;
     }
-    fprintf(trace, "%s", (char*)ldns_buffer_begin(lbuf));
+    char* p = (char*)ldns_buffer_begin(lbuf);
+    for (; *p; p++) {
+        if (*p == ',') {
+            fputc('\\', trace);
+        }
+        fputc(*p, trace);
+    }
 
     // class
     ldns_buffer_clear(lbuf);


### PR DESCRIPTION
- Fix #314:
  - man-page: Clarify that `pktsize` is shown before parsing the IP packet
  - `-g`: Quote `,` characters