### PR TITLE
Add support for 64bit time structures on 32bit systems

### DIFF
--- a/plugins/pcapdump/pcapdump.c
+++ b/plugins/pcapdump/pcapdump.c
@@ -175,10 +175,10 @@ int pcapdump_open(my_bpftimeval ts)
             ts.tv_sec++;
             ts.tv_usec -= MILLION;
         }
-        gmtime_r((time_t*)&ts.tv_sec, &tm);
+        gmtime_r(&ts.tv_sec, &tm);
         strftime(sbuf, 64, "%Y%m%d.%H%M%S", &tm);
-        if (asprintf(&dumpname, "%s.%s.%06lu",
-                dump_base, sbuf, (u_long)ts.tv_usec)
+        if (asprintf(&dumpname, "%s.%s.%06" PRI_tv_usec,
+                dump_base, sbuf, ts.tv_usec)
                 < 0
             || asprintf(&dumpnamepart, "%s.part", dumpname) < 0) {
             logerr("asprintf: %s", strerror(errno));

--- a/plugins/rssm/rssm.c
+++ b/plugins/rssm/rssm.c
@@ -286,7 +286,7 @@ void rssm_save_counts(const char* sbuf)
     FILE* fp;
     int   i;
     char* tbuf = 0;
-    i          = asprintf(&tbuf, "%s.%s.%06lu", counts_prefix ? counts_prefix : COUNTS_PREFIX_DEFAULT, sbuf, (u_long)open_ts.tv_usec);
+    i          = asprintf(&tbuf, "%s.%s.%06" PRI_tv_usec, counts_prefix ? counts_prefix : COUNTS_PREFIX_DEFAULT, sbuf, open_ts.tv_usec);
     if (i < 1 || !tbuf) {
         logerr("asprintf: out of memory");
         return;
@@ -302,7 +302,7 @@ void rssm_save_counts(const char* sbuf)
         char      tz[21];
         struct tm tm;
 
-        gmtime_r((time_t*)&open_ts.tv_sec, &tm);
+        gmtime_r(&open_ts.tv_sec, &tm);
         if (!strftime(tz, sizeof(tz), "%Y-%m-%dT%H:%M:%SZ", &tm)) {
             logerr("rssm: strftime failed");
             fclose(fp);
@@ -443,8 +443,8 @@ void rssm_save_counts(const char* sbuf)
             }
         }
     } else {
-        fprintf(fp, "first-packet-time %ld\n", (long)open_ts.tv_sec);
-        fprintf(fp, "last-packet-time %ld\n", (long)close_ts.tv_sec);
+        fprintf(fp, "first-packet-time %" PRI_tv_sec "\n", open_ts.tv_sec);
+        fprintf(fp, "last-packet-time %" PRI_tv_sec "\n", close_ts.tv_sec);
         fprintf(fp, "dns-udp-queries-received-ipv4 %" PRIu64 "\n", counts.dns_udp_queries_received_ipv4);
         fprintf(fp, "dns-udp-queries-received-ipv6 %" PRIu64 "\n", counts.dns_udp_queries_received_ipv6);
         fprintf(fp, "dns-tcp-queries-received-ipv4 %" PRIu64 "\n", counts.dns_tcp_queries_received_ipv4);
@@ -510,7 +510,7 @@ void rssm_save_sources(const char* sbuf)
     FILE* fp;
     char* tbuf = 0;
     int   i;
-    i = asprintf(&tbuf, "%s.%s.%06lu", sources_prefix, sbuf, (u_long)open_ts.tv_usec);
+    i = asprintf(&tbuf, "%s.%s.%06" PRI_tv_usec, sources_prefix, sbuf, open_ts.tv_usec);
     if (i < 1 || !tbuf) {
         logerr("asprintf: out of memory");
         return;
@@ -535,7 +535,7 @@ void rssm_save_aggregated(const char* sbuf)
     FILE* fp;
     char* tbuf = 0;
     int   i;
-    i = asprintf(&tbuf, "%s.%s.%06lu", aggregated_prefix, sbuf, (u_long)open_ts.tv_usec);
+    i = asprintf(&tbuf, "%s.%s.%06" PRI_tv_usec, aggregated_prefix, sbuf, open_ts.tv_usec);
     if (i < 1 || !tbuf) {
         logerr("asprintf: out of memory");
         return;
@@ -566,7 +566,7 @@ int rssm_close(my_bpftimeval ts)
     struct tm tm;
 
     if (dont_fork_on_close) {
-        gmtime_r((time_t*)&open_ts.tv_sec, &tm);
+        gmtime_r(&open_ts.tv_sec, &tm);
         strftime(sbuf, sizeof(sbuf), "%Y%m%d.%H%M%S", &tm);
         close_ts = ts;
         rssm_save_counts(sbuf);
@@ -596,7 +596,7 @@ int rssm_close(my_bpftimeval ts)
         exit(0);
     }
     /* grandchild (2nd gen) continues */
-    gmtime_r((time_t*)&open_ts.tv_sec, &tm);
+    gmtime_r(&open_ts.tv_sec, &tm);
     strftime(sbuf, sizeof(sbuf), "%Y%m%d.%H%M%S", &tm);
     close_ts = ts;
     rssm_save_counts(sbuf);

--- a/plugins/rzkeychange/rzkeychange.c
+++ b/plugins/rzkeychange/rzkeychange.c
@@ -290,8 +290,8 @@ void rzkeychange_submit_counts(void)
     double    elapsed = (double)clos_ts.tv_sec - (double)open_ts.tv_sec + 0.000001 * clos_ts.tv_usec - 0.000001 * open_ts.tv_usec; // NOSONAR
     int       k;
 
-    k = snprintf(qname, sizeof(qname), "%lu-%u-%" PRIu64 "-%" PRIu64 "-%" PRIu64 "-%" PRIu64 "-%" PRIu64 "-%" PRIu64 "-%" PRIu64 ".%s.%s.%s",
-        (u_long)open_ts.tv_sec,
+    k = snprintf(qname, sizeof(qname), "%" PRI_tv_sec "-%u-%" PRIu64 "-%" PRIu64 "-%" PRIu64 "-%" PRIu64 "-%" PRIu64 "-%" PRIu64 "-%" PRIu64 ".%s.%s.%s",
+        open_ts.tv_sec,
         (unsigned int)(elapsed + 0.5),
         counts.total,
         counts.dnskey,
@@ -330,8 +330,8 @@ void rzkeychange_submit_counts(void)
                 if (*t == '.' || *t == ':')
                     *t = '-';
 
-            k = snprintf(qname, sizeof(qname), "%lu.%s.%hhx.%s.%s.%s.%s",
-                (u_long)open_ts.tv_sec,
+            k = snprintf(qname, sizeof(qname), "%" PRI_tv_sec ".%s.%hhx.%s.%s.%s.%s",
+                open_ts.tv_sec,
                 s,
                 key_tag_signals[i].flags,
                 key_tag_signals[i].signal,

--- a/plugins/txtout/txtout.c
+++ b/plugins/txtout/txtout.c
@@ -220,7 +220,7 @@ void txtout_output(const char* descr, iaddr from, iaddr to, uint8_t proto, unsig
     /*
      * IP Stuff
      */
-    fprintf(out, "%10ld.%06ld", (long)ts.tv_sec, (long)ts.tv_usec);
+    fprintf(out, "%10" PRI_tv_sec ".%06" PRI_tv_usec, ts.tv_sec, ts.tv_usec);
     fprintf(out, " %s %u", ia_str(from), sport);
     fprintf(out, " %s %u", ia_str(to), dport);
     fprintf(out, " %hhu", proto);

--- a/src/dnscap.c
+++ b/src/dnscap.c
@@ -143,8 +143,8 @@ int main(int argc, char* argv[])
             struct tm tm;
             gmtime_r(&start_time, &tm);
             strftime(when, sizeof when, "%F %T", &tm);
-            fprintf(stderr, "Sleeping for %d seconds until %s UTC\n",
-                (int)(start_time - now.tv_sec), when);
+            fprintf(stderr, "Sleeping for %" PRI_tv_sec " seconds until %s UTC\n",
+                start_time - now.tv_sec, when);
             sleep(start_time - now.tv_sec);
             fprintf(stderr, "Awake.\n");
         }

--- a/src/dnscap_common.h
+++ b/src/dnscap_common.h
@@ -49,6 +49,21 @@
 #endif
 #endif
 
+/* Macros for printing timeval */
+#include <inttypes.h>
+#if _TIME_BITS == 64
+#define PRI_tv_sec PRId64
+#define PRI_tv_usec PRId64
+#else
+#ifdef __OpenBSD__
+#define PRI_tv_sec PRId64
+#define PRI_tv_usec "ld"
+#else
+#define PRI_tv_sec "ld"
+#define PRI_tv_usec "ld"
+#endif
+#endif
+
 /*
  * setup MY_BPFTIMEVAL as the timeval structure that bpf packets
  * will be assoicated with packets from libpcap

--- a/src/dumper.c
+++ b/src/dumper.c
@@ -198,7 +198,7 @@ int dumper_open(my_bpftimeval ts)
 
         gmtime_r((time_t*)&ts.tv_sec, &tm);
         strftime(sbuf, 64, "%Y%m%d.%H%M%S", &tm);
-        if (asprintf(&dumpname, "%s.%s.%06ld%s",
+        if (asprintf(&dumpname, "%s.%s.%06" PRI_tv_usec "%s",
                 dump_base, sbuf,
                 ts.tv_usec, dump_suffix ? dump_suffix : "")
                 < 0

--- a/src/network.c
+++ b/src/network.c
@@ -192,7 +192,7 @@ void layer_pkt(u_char* user, const pcap_thread_packet_t* packet, const u_char* p
                 break;
         }
 
-        t = (time_t)firstpkt->pkthdr.ts.tv_sec;
+        t = firstpkt->pkthdr.ts.tv_sec;
         gmtime_r(&t, &tm);
         strftime(when, sizeof(when), "%Y-%m-%d %T", &tm);
 
@@ -207,7 +207,7 @@ void layer_pkt(u_char* user, const pcap_thread_packet_t* packet, const u_char* p
         }
 
         if (vlan != MAX_VLAN) {
-            snprintf(descr, sizeof(descr), "[%zu] %s.%06ld [#%zd %s (vlan %u) %u] \\\n",
+            snprintf(descr, sizeof(descr), "[%zu] %s.%06" PRI_tv_usec " [#%zd %s (vlan %u) %u] \\\n",
                 len,
                 when,
                 firstpkt->pkthdr.ts.tv_usec,
@@ -216,7 +216,7 @@ void layer_pkt(u_char* user, const pcap_thread_packet_t* packet, const u_char* p
                 vlan,
                 vlan);
         } else {
-            snprintf(descr, sizeof(descr), "[%zu] %s.%06ld [#%zd %s %u] \\\n",
+            snprintf(descr, sizeof(descr), "[%zu] %s.%06" PRI_tv_usec " [#%zd %s %u] \\\n",
                 len,
                 when,
                 firstpkt->pkthdr.ts.tv_usec,
@@ -426,7 +426,7 @@ void dl_pkt(u_char* user, const struct pcap_pkthdr* hdr, const u_char* pkt, cons
         struct tm   tm;
         time_t      t;
 
-        t = (time_t)hdr->ts.tv_sec;
+        t = hdr->ts.tv_sec;
         gmtime_r(&t, &tm);
         strftime(when, sizeof when, "%Y-%m-%d %T", &tm);
         if (vlan != MAX_VLAN) {
@@ -437,7 +437,7 @@ void dl_pkt(u_char* user, const struct pcap_pkthdr* hdr, const u_char* pkt, cons
         } else {
             viap = "\"some interface\"";
         }
-        snprintf(descr, sizeof(descr), "[%zu] %s.%06ld [#%zu %s %u] \\\n",
+        snprintf(descr, sizeof(descr), "[%zu] %s.%06" PRI_tv_usec " [#%zu %s %u] \\\n",
             len, when, hdr->ts.tv_usec, msgcount, viap, vlan);
     } else {
         descr[0] = '\0';
@@ -725,9 +725,9 @@ void network_pkt2(const char* descr, my_bpftimeval ts, const pcap_thread_packet_
 
         tcpstate = tcpstate_find(from, to, sport, dport, ts.tv_sec);
         if (dumptrace >= 3) {
-            fprintf(stderr, "%s: tcp pkt: %" PRIdMAX ".%06ld [%4zu] %15s -> ",
+            fprintf(stderr, "%s: tcp pkt: %" PRI_tv_sec ".%06" PRI_tv_usec " [%4zu] %15s -> ",
                 ProgramName,
-                (intmax_t)ts.tv_sec,
+                ts.tv_sec,
                 ts.tv_usec,
                 len,
                 ia_str(from));
@@ -1327,8 +1327,8 @@ void network_pkt(const char* descr, my_bpftimeval ts, unsigned pf,
 
         tcpstate = tcpstate_find(from, to, sport, dport, ts.tv_sec);
         if (dumptrace >= 3) {
-            fprintf(stderr, "%s: tcp pkt: %" PRIdMAX ".%06ld [%4zu] ", ProgramName,
-                (intmax_t)ts.tv_sec, ts.tv_usec, len);
+            fprintf(stderr, "%s: tcp pkt: %" PRI_tv_sec ".%06" PRI_tv_usec " [%4zu] ", ProgramName,
+                ts.tv_sec, ts.tv_usec, len);
             fprintf(stderr, "%15s -> ", ia_str(from));
             fprintf(stderr, "%15s; ", ia_str(to));
             if (tcpstate)


### PR DESCRIPTION
- Fix #324:
  - Add macros for printing `timeval` when `_TIME_BITS` is set to 64
  - Clean up usage and printing of `timeval` structures in `src` and `plugins`