### PR TITLE
plugin close

### DIFF
--- a/src/dnscap.h
+++ b/src/dnscap.h
@@ -355,7 +355,7 @@ struct plugin {
     int (*start)(logerr_t*);
     void (*stop)();
     int (*open)(my_bpftimeval);
-    int (*close)();
+    int (*close)(my_bpftimeval);
     output_t(*output);
     filter_t(*filter);
     void (*getopt)(int*, char**[]);

--- a/src/dumper.c
+++ b/src/dumper.c
@@ -379,7 +379,7 @@ int dumper_close(my_bpftimeval ts)
         int x;
         if (!p->close)
             continue;
-        x = (*p->close)();
+        x = (*p->close)(ts);
         if (x)
             logerr("%s_close returned %d", p->name, x);
     }


### PR DESCRIPTION
- Fix #334:
  - Readd timestamp when calling plugin close
  - Update plugin close interface to pass timestamp that was missed in 2f65abd0ea059046a3ab54260806891d557d1180