### PR TITLE
breakloop

### DIFF
--- a/src/args.c
+++ b/src/args.c
@@ -41,6 +41,7 @@
 #include "tcpstate.h"
 #include "network.h"
 #include "dumper.h"
+#include "pcaps.h"
 
 #include <ldns/ldns.h>
 
@@ -630,6 +631,7 @@ void parse_args(int argc, char* argv[])
                 (*pl->extension)(DNSCAP_EXT_SET_OUTPUT_PKT, (set_output_pkt_t)set_output_pkt);
                 (*pl->extension)(DNSCAP_EXT_GET_PCAP_THREAD_FTELL, (get_pcap_thread_ftell_t)_get_pcap_thread_ftell);
                 (*pl->extension)(DNSCAP_EXT_GET_PKTHDR_CAPLEN, (get_pkthdr_caplen_t)_get_pkthdr_caplen);
+                (*pl->extension)(DNSCAP_EXT_BREAKLOOP_PCAPS, (breakloop_pcaps_t)breakloop_pcaps);
             }
             snprintf(sn, sizeof(sn), "%s_getopt", pl->name);
             pl->getopt = dlsym(pl->handle, sn);

--- a/src/dnscap_common.h
+++ b/src/dnscap_common.h
@@ -158,6 +158,9 @@ typedef long (*get_pcap_thread_ftell_t)(void);
 #define DNSCAP_EXT_GET_PKTHDR_CAPLEN 8
 typedef size_t (*get_pkthdr_caplen_t)(void);
 
+#define DNSCAP_EXT_BREAKLOOP_PCAPS 9
+typedef void (*breakloop_pcaps_t)(void);
+
 /*
  * Flags
  */


### PR DESCRIPTION
- Add new extension `DNSCAP_EXT_BREAKLOOP_PCAPS`, expose function for stopping the PCAP process/capture loop